### PR TITLE
Use content instead of reason phrase

### DIFF
--- a/Library/Extensions/HttpResponseMessageExtensions.cs
+++ b/Library/Extensions/HttpResponseMessageExtensions.cs
@@ -38,33 +38,33 @@ namespace Nfield.Extensions
                 return response;
             }
 
-            var message = response.Content.ReadAsStringAsync().Result;
+            var message = response.Content?.ReadAsStringAsync().Result;
             if (string.IsNullOrEmpty(message))
             {
                 message = response.ReasonPhrase;
             }
-
-            Dictionary<string, object> httpErrorDictionary = null;
-            if (response.Content != null)
+            else
             {
                 try
                 {
-                    httpErrorDictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(message);
+                    var httpErrorDictionary = JsonConvert.DeserializeObject<Dictionary<string, object>>(message);
+                    object temp;
+                    if (httpErrorDictionary.TryGetValue("NfieldErrorCode", out temp))
+                    {
+                        var nfieldErrorCode = (NfieldErrorCode)Enum.Parse(typeof(NfieldErrorCode), temp.ToString());
+
+                        var nfieldMessage = httpErrorDictionary.TryGetValue("Message", out temp)
+                            ? temp.ToString()
+                            : message;
+
+                        throw new NfieldErrorException(response.StatusCode, nfieldErrorCode, nfieldMessage);
+                    }
                 }
-                catch (Exception)
+                catch (JsonException)
                 {
                     // it's not json
                 }
-            }
 
-            object temp;
-            if (httpErrorDictionary != null && httpErrorDictionary.TryGetValue("NfieldErrorCode", out temp))
-            {
-                NfieldErrorCode nfieldErrorCode = (NfieldErrorCode)Enum.Parse(typeof(NfieldErrorCode), temp.ToString());
-
-                string nfieldMessage = httpErrorDictionary.TryGetValue("Message", out temp) ? temp.ToString() : message;
-
-                throw new NfieldErrorException(response.StatusCode, nfieldErrorCode, nfieldMessage);
             }
 
             throw new NfieldHttpResponseException(response.StatusCode, message);

--- a/Library/Infrastructure/NfieldErrorCode.cs
+++ b/Library/Infrastructure/NfieldErrorCode.cs
@@ -23,6 +23,12 @@ namespace Nfield.Infrastructure
         public enum NfieldErrorCode
         {
             /// <summary>
+            /// No error code is returned. This should never be returned in production code and is mainly added
+            /// to be able to test that the expected error code is used.
+            /// </summary>
+            None,
+
+            /// <summary>
             /// (One of the) provided arguments is null
             /// </summary>
             ArgumentIsNull,
@@ -45,7 +51,32 @@ namespace Nfield.Infrastructure
             /// <summary>
             /// Database cannot be updated
             /// </summary>
-            DataUpdateError
+            DataUpdateError,
+
+            /// <summary>
+            /// An unknown server error has occurred
+            /// </summary>
+            UnknownServerError,
+
+            /// <summary>
+            /// The requested entity could not be found
+            /// </summary>
+            EntityNotFound,
+
+            /// <summary>
+            /// The user could not be authenticated. Either the domain name, the username or the password is incorrect.
+            /// </summary>
+            NotAuthenticated,
+
+            /// <summary>
+            /// Access to the requested domain has been blocked by the SaaS Administrator
+            /// </summary>
+            DomainAccessDenied,
+
+            /// <summary>
+            /// This means an invalid survey type. (e.g. request sampling points for a survey that is not of this specific type)
+            /// </summary>
+            InvalidSurveyType
         }
     }
 }


### PR DESCRIPTION
In the Nfield API we stop using reason phrase because it has become less supported as we upgrade the Azure deployments.

It is also no longer supported in [HTTP/2](https://http2.github.io/http2-spec/):
> HTTP/2 does not define a way to carry the version or reason phrase that is included in an HTTP/1.1 status line