### PR TITLE
Add method to create fieldwork office

### DIFF
--- a/Library/Services/INfieldFieldworkOfficesService.cs
+++ b/Library/Services/INfieldFieldworkOfficesService.cs
@@ -35,5 +35,13 @@ namespace Nfield.Services
         /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
         /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>   
         Task<IQueryable<FieldworkOffice>> QueryAsync();
+
+        /// <summary>
+        /// Creates a new fieldwork office
+        /// </summary>
+        /// <param name="name">Name of the office</param>
+        /// <param name="description">Description of the office</param>
+        /// <returns>The fieldwork office created</returns>
+        Task<FieldworkOffice> CreateFieldworkOfficeAsync(string name, string description);
     }
 }

--- a/Library/Services/Implementation/NfieldFieldworkOfficesService.cs
+++ b/Library/Services/Implementation/NfieldFieldworkOfficesService.cs
@@ -45,6 +45,22 @@ namespace Nfield.Services.Implementation
              .FlattenExceptions();
         }
 
+        /// <summary>
+        /// See <see cref="INfieldFieldworkOfficesService.CreateFieldworkOfficeAsync"/>
+        /// </summary>
+        public Task<FieldworkOffice> CreateFieldworkOfficeAsync(string name, string description)
+        {
+            var fieldworkOffice = new FieldworkOffice() { OfficeName = name, Description = description };
+
+            return ConnectionClient.Client.PostAsJsonAsync(OfficesApi.AbsoluteUri, fieldworkOffice)
+                .ContinueWith(
+                    responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                .ContinueWith(
+                    stringTask =>
+                        JsonConvert.DeserializeObject<FieldworkOffice>(stringTask.Result))
+                .FlattenExceptions();
+        }
+
         #endregion
 
         #region Implementation of INfieldConnectionClientObject


### PR DESCRIPTION
For the story [Remove online survey from Classic Manager Slice 1](https://niposoftware.visualstudio.com/Nfield/_workitems/edit/27276).

Adds a method to create a fieldwork office in Nfield.SDK that will be used by the SaaS Admin tests to avoid referring to the hidden API.