### PR TITLE
[Story] Get VAR file for questionnaire

### DIFF
--- a/Library/BuildPackage.cmd
+++ b/Library/BuildPackage.cmd
@@ -1,0 +1,3 @@
+del Nfield.SDK.1.0.0.nupkg
+nuget pack Nfield.SDK.csproj -build -properties Configuration=Debug
+pause

--- a/Library/Infrastructure/NfieldSdkInitializer.cs
+++ b/Library/Infrastructure/NfieldSdkInitializer.cs
@@ -70,6 +70,7 @@ namespace Nfield.Infrastructure
             registerTransient(typeof(INfieldEncryptionUtility), typeof(NfieldEncryptionUtility));
             registerTransient(typeof(IAesManagedWrapper), typeof(AesManagedWrapper));
             registerTransient(typeof(INfieldSurveyInviteRespondentsService), typeof(NfieldSurveyInviteRespondentsService));
+            registerTransient(typeof(INfieldSurveyVarFileService), typeof(NfieldSurveyVarFileService));
         }
 
     }

--- a/Library/Models/InvitationBatch.cs
+++ b/Library/Models/InvitationBatch.cs
@@ -46,7 +46,7 @@ namespace Nfield.Models
 
         /// <summary>
         /// List of sample records to send the invitation to.
-        /// If this is null then the batch will be sent using the <see cref="Filters"/>
+        /// If this is null then the batch will be sent using the <see cref="InvitationBatchWithFilter.Filters"/>
         /// </summary>
         public IEnumerable<string> RespondentKeys { get; set; }
     }

--- a/Library/Models/InvitationBatchWithFilter.cs
+++ b/Library/Models/InvitationBatchWithFilter.cs
@@ -46,7 +46,7 @@ namespace Nfield.Models
 
         /// <summary>
         /// Respondent filters.
-        /// If this is null then the batch will be sent for all <see cref="RespondentKeys"/>
+        /// If this is null then the batch will be sent for all <see cref="InvitationBatch.RespondentKeys"/>
         /// </summary>
         public IEnumerable<SampleFilter> Filters { get; set; }
 

--- a/Library/Models/SurveyVarFile.cs
+++ b/Library/Models/SurveyVarFile.cs
@@ -1,0 +1,33 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.Models
+{
+    /// <summary>
+    /// Model for the varfile for a survey
+    /// </summary>
+    public class SurveyVarFile
+    {
+        /// <summary>
+        /// The content
+        /// </summary>
+        public string FileContent { get; set; }
+
+        /// <summary>
+        /// The suggested file name
+        /// </summary>
+        public string FileName { get; set; }
+    }
+}

--- a/Library/Nfield.SDK.csproj
+++ b/Library/Nfield.SDK.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Models\SurveyScript.cs" />
     <Compile Include="Models\SurveySetting.cs" />
     <Compile Include="Models\SurveyType.cs" />
+    <Compile Include="Models\SurveyVarFile.cs" />
     <Compile Include="Models\Translation.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Extensions\HttpResponseMessageExtensions.cs" />
@@ -194,6 +195,7 @@
     <Compile Include="Services\Implementation\NfieldSurveyRelocationsService.cs" />
     <Compile Include="Services\Implementation\NfieldSurveyPublicIdsService.cs" />
     <Compile Include="Services\Implementation\NfieldSurveySettingsService.cs" />
+    <Compile Include="Services\Implementation\NfieldSurveyVarFileService.cs" />
     <Compile Include="Services\Implementation\NfieldTranslationsService.cs" />
     <Compile Include="Services\INfieldAddressesService.cs" />
     <Compile Include="Services\INfieldBackgroundTasksService.cs" />
@@ -227,6 +229,7 @@
     <Compile Include="Services\INfieldSurveyPublicIdsService.cs" />
     <Compile Include="Services\INfieldSurveySettingsService.cs" />
     <Compile Include="Services\INfieldSurveysService.cs" />
+    <Compile Include="Services\INfieldSurveyVarFileService.cs" />
     <Compile Include="Services\INfieldTranslationsService.cs" />
     <Compile Include="Services\Implementation\NfieldSurveyResponseCodesService.cs" />
     <Compile Include="Services\Implementation\NfieldSurveyInterviewersService.cs" />

--- a/Library/Services/INfieldSurveyVarFileService.cs
+++ b/Library/Services/INfieldSurveyVarFileService.cs
@@ -1,0 +1,36 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Nfield.Models;
+using System.Threading.Tasks;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Represents a set of methods to get a varfile for a survey.
+    /// </summary>
+    public interface INfieldSurveyVarFileService
+    {
+        /// <summary>
+        /// Gets the varfile for survey.
+        /// </summary>
+        Task<SurveyVarFile> GetAsync(string surveyId);
+
+        /// <summary>
+        /// Gets specific version of the varfile.
+        /// </summary>
+        Task<SurveyVarFile> GetAsync(string surveyId, string eTag);
+    }
+}

--- a/Library/Services/Implementation/NfieldSurveyVarFileService.cs
+++ b/Library/Services/Implementation/NfieldSurveyVarFileService.cs
@@ -1,0 +1,93 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Newtonsoft.Json;
+using Nfield.Extensions;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nfield.Services.Implementation
+{
+    /// <summary>
+    /// Implementation of <see cref="INfieldSurveyVarFileService"/>
+    /// </summary>
+    internal class NfieldSurveyVarFileService : INfieldSurveyVarFileService, INfieldConnectionClientObject
+    {
+
+        #region Implementation of INfieldSurveyVarFileService
+
+        /// <summary>
+        /// See <see cref="INfieldSurveyVarFileService.GetAsync(string)"/>
+        /// </summary>
+        public Task<SurveyVarFile> GetAsync(string surveyId)
+        {
+            var uri = SurveyVarFileUrl(surveyId);
+            return Client.GetAsync(uri)
+                .ContinueWith(
+                    responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                .ContinueWith(
+                    stringTask =>
+                        JsonConvert.DeserializeObject<SurveyVarFile>(stringTask.Result))
+                .FlattenExceptions();
+        }
+
+        /// <summary>
+        /// See <see cref="INfieldSurveyScriptService.GetAsync(string, string)"/> 
+        /// </summary>
+        public Task<SurveyVarFile> GetAsync(string surveyId, string eTag)
+        {
+            var uri = SurveyVarFileUrl(surveyId, eTag);
+            return Client.GetAsync(uri)
+                .ContinueWith(
+                    responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                .ContinueWith(
+                    stringTask =>
+                        JsonConvert.DeserializeObject<SurveyVarFile>(stringTask.Result))
+                .FlattenExceptions();
+        }
+
+        #endregion
+
+        #region Implementation of INfieldConnectionClientObject
+
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        #endregion
+
+        private INfieldHttpClient Client
+        {
+            get { return ConnectionClient.Client; }
+        }
+
+        private string SurveyVarFileUrl(string surveyId, string eTag = null)
+        {
+            var result = new StringBuilder(ConnectionClient.NfieldServerUri.AbsoluteUri);
+            result.AppendFormat(CultureInfo.InvariantCulture, @"Surveys/{0}/VarFile/", surveyId);
+
+            if (!string.IsNullOrEmpty(eTag))
+                result.AppendFormat("{0}", eTag);
+
+            return result.ToString();
+        }
+    }
+}

--- a/Tests/Nfield.SDK.Tests.csproj
+++ b/Tests/Nfield.SDK.Tests.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Services\NfieldSurveyPublicIdsServiceTests.cs" />
     <Compile Include="Services\NfieldSurveySettingsServiceTests.cs" />
     <Compile Include="Services\NfieldSurveysServiceTests.cs" />
+    <Compile Include="Services\NfieldSurveyVarFileServiceTests.cs" />
     <Compile Include="Services\NfieldTranslationsServiceTests.cs" />
     <Compile Include="TestHelpers\TaskHelpers.cs" />
     <Compile Include="Utilities\NfieldEncryptionUtilityTests.cs" />

--- a/Tests/Services/NfieldSurveyVarFileServiceTests.cs
+++ b/Tests/Services/NfieldSurveyVarFileServiceTests.cs
@@ -1,0 +1,87 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using Nfield.Services.Implementation;
+using System.Net;
+using System.Net.Http;
+using Xunit;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Tests for <see cref="NfieldSurveyVarFileService"/>
+    /// </summary>
+    public class NfieldSurveyVarFileServiceTests : NfieldServiceTestsBase
+    {
+        private readonly NfieldSurveyVarFileService _target;
+        readonly Mock<INfieldHttpClient> _mockedHttpClient;
+
+        public NfieldSurveyVarFileServiceTests()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            _mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            _target = new NfieldSurveyVarFileService();
+            _target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+        }
+        #region GetAsync
+
+        [Fact]
+        public void TestGetAsync_WhenScriptExists_ReturnsCorrectVarFile()
+        {
+            const string surveyId = "SurveyId";
+            const string varFile = "this is the varFile";
+            const string fileName = "file.var";
+
+            var expected = new SurveyVarFile { FileContent = varFile, FileName = fileName };
+
+            _mockedHttpClient
+                 .Setup(client => client.GetAsync($"{ServiceAddress}Surveys/{surveyId}/VarFile/"))
+                 .Returns(CreateTask(HttpStatusCode.OK, new StringContent(JsonConvert.SerializeObject(expected))));
+
+            var actual = _target.GetAsync(surveyId).Result;
+
+            Assert.Equal(varFile, actual.FileContent);
+            Assert.Equal(fileName, actual.FileName);
+        }
+
+        [Fact]
+        public void TestGetAsync_WhenSpecificVersionOfScriptExits_ReturnsCorrectScript()
+        {
+            const string surveyId = "SurveyId";
+            const string varFile = "this is the varFile";
+            const string fileName = "file.var";
+            const string eTag = "etag";
+
+            var expected = new SurveyVarFile { FileContent = varFile, FileName = fileName };
+
+            _mockedHttpClient
+                 .Setup(client => client.GetAsync($"{ServiceAddress}Surveys/{surveyId}/VarFile/{eTag}"))
+                 .Returns(CreateTask(HttpStatusCode.OK, new StringContent(JsonConvert.SerializeObject(expected))));
+
+            var actual = _target.GetAsync(surveyId, eTag).Result;
+
+            Assert.Equal(varFile, actual.FileContent);
+            Assert.Equal(fileName, actual.FileName);
+        }
+
+        #endregion
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ branches:
     - /ci-.+/
 
 version: 1.5.{build}
+configuration: Release
 
 install:
   - ps: ./prerelease.ps1 # this will update the package name to mark it as prerelease


### PR DESCRIPTION
The VAR-file is currently obtained from the questionnaire file through Odin Developer, in a ‘manual’ process. Customers want to make VAR-file retrieval part of an automated process.

API that accepts survey-id and version-id and returns VAR-file
If only survey-id specified (no version-id), return VAR-file for current (latest) uploaded script

Pro: For a survey that is running in Nfield, user doesn’t first have to get the script (through API) to then push it into API to get VAR-file. In the total automation process, this should not be an issue at all.
Con: User can only get VAR-file for script that has been published in Nfield.

The version ID for the published test and live link can be obtained through the INfieldSurveyPackageService service.