### PR TITLE
[STORY] Add interview parameter for data download

### DIFF
--- a/Library/Models/SurveyDownloadDataRequest.cs
+++ b/Library/Models/SurveyDownloadDataRequest.cs
@@ -28,6 +28,12 @@ namespace Nfield.Models
         public string SurveyId { get; set; }
 
         /// <summary>
+        /// The id of the interview to download the data.
+        /// It will be present only if we want to download data for a single interview.
+        /// </summary>
+        public int? InterviewId { get; set; }
+
+        /// <summary>
         /// Download data of test interviews
         /// </summary>
         public bool DownloadTestInterviewData { get; set; }

--- a/Library/Services/Implementation/NfieldSurveyDataService.cs
+++ b/Library/Services/Implementation/NfieldSurveyDataService.cs
@@ -24,7 +24,7 @@ namespace Nfield.Services.Implementation
         {
             if (surveyDownloadDataRequest == null)
             {
-                throw new ArgumentNullException("surveyDownloadDataRequest");
+                throw new ArgumentNullException(nameof(surveyDownloadDataRequest));
             }
             var uri = SurveyDataUrl(surveyDownloadDataRequest.SurveyId);
 


### PR DESCRIPTION
Add interview id parameter used for downloading the data for a single respondent (for GDPR purposes)