### PR TITLE
Clear by interview id

### DIFF
--- a/Library/Services/INfieldSurveySampleService.cs
+++ b/Library/Services/INfieldSurveySampleService.cs
@@ -77,9 +77,10 @@ namespace Nfield.Services
         /// </summary>
         /// <param name="surveyId">The id of the survey</param>
         /// <param name="respondentKey">The id of the respondent to be cleared</param>
+        /// <param name="interviewId">The interview id to be cleared</param>
         /// <param name="columnsToClear">The name of the columns to be cleared</param>
         /// <returns>The number of respondents successfully clear</returns>
-        Task<int> ClearAsync(string surveyId, string respondentKey, IEnumerable<string> columnsToClear);
+        Task<int> ClearAsync(string surveyId, string respondentKey, int? interviewId, IEnumerable<string> columnsToClear);
 
         /// <summary>
         /// Updates the specified custom columns for the specified record in the survey.

--- a/Library/Services/Implementation/NfieldSurveySampleService.cs
+++ b/Library/Services/Implementation/NfieldSurveySampleService.cs
@@ -133,22 +133,33 @@ namespace Nfield.Services.Implementation
                 .FlattenExceptions();
         }
 
-        public Task<int> ClearAsync(string surveyId, string respondentKey, IEnumerable<string> columnsToClear)
+        public Task<int> ClearAsync(string surveyId, string respondentKey, int? interviewId, IEnumerable<string> columnsToClear)
         {
             Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
-            Ensure.ArgumentNotNullOrEmptyString(respondentKey, nameof(respondentKey));
 
             if (columnsToClear == null || !columnsToClear.Any())
             {
                 throw new ArgumentException(nameof(columnsToClear));
             }
 
+            if (string.IsNullOrEmpty(respondentKey) && !interviewId.HasValue)
+            {
+                throw new ArgumentException("RespondentKey or InterviewId must be specified");
+            }
+
             var uri = SurveySampleUrl(surveyId) + @"/Clear";
 
-            var filters = new List<SampleFilter>
+            var filters = new List<SampleFilter>();
+
+            if (!string.IsNullOrEmpty(respondentKey))
             {
-                new SampleFilter{Name = "RespondentKey", Op = "eq", Value = respondentKey}
-            };
+                filters.Add(new SampleFilter{Name = "RespondentKey", Op = "eq", Value = respondentKey});
+            }
+
+            if (interviewId.HasValue)
+            {
+                filters.Add(new SampleFilter { Name = "InterviewId", Op = "eq", Value = interviewId.ToString() });
+            }
 
             var request = new ClearSurveySampleModel
             {


### PR DESCRIPTION
Clear also by interview id. Capi surveys don't have respondent key, so we should be also able to clear sample data by interview id