### PR TITLE
[Issue] Purple/ci fix issue 385

### DIFF
--- a/Library/Models/SamplingPointQuotaTarget.cs
+++ b/Library/Models/SamplingPointQuotaTarget.cs
@@ -27,7 +27,7 @@ namespace Nfield.Models
         /// The Id of the Quota Level
         /// </summary>
         [JsonProperty]
-        public string LevelId { get; internal set; }
+        public string LevelId { get; set; }
 
         /// <summary>
         /// Actual target of the level

--- a/Library/Models/SamplingPointQuotaTarget.cs
+++ b/Library/Models/SamplingPointQuotaTarget.cs
@@ -27,7 +27,7 @@ namespace Nfield.Models
         /// The Id of the Quota Level
         /// </summary>
         [JsonProperty]
-        public string LevelId { get; set; }
+        public string LevelId { get; internal set; }
 
         /// <summary>
         /// Actual target of the level

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,4 +32,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: InternalsVisibleTo("Nfield.SDK.Tests")]
+[assembly: InternalsVisibleTo("Nfield.Manager.Api.IntegrationTests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/Library/Services/Implementation/NfieldSurveysService.cs
+++ b/Library/Services/Implementation/NfieldSurveysService.cs
@@ -27,6 +27,7 @@ using Nfield.Extensions;
 using Nfield.Infrastructure;
 using Nfield.Models;
 using Nfield.Quota;
+using Nfield.Utilities;
 
 namespace Nfield.Services.Implementation
 {
@@ -375,10 +376,10 @@ namespace Nfield.Services.Implementation
         /// </summary>
         public Task<SamplingPointQuotaTarget> SamplingPointQuotaTargetUpdateAsync(string surveyId, string samplingPointId, SamplingPointQuotaTarget samplingPointQuotaTarget)
         {
-            if (samplingPointQuotaTarget == null)
-            {
-                throw new ArgumentNullException("samplingPointQuotaTarget");
-            }
+            Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
+            Ensure.ArgumentNotNullOrEmptyString(samplingPointId, nameof(samplingPointId));
+            Ensure.ArgumentNotNull(samplingPointQuotaTarget, nameof(samplingPointQuotaTarget));
+            Ensure.ArgumentNotNullOrEmptyString(samplingPointQuotaTarget.LevelId, nameof(samplingPointQuotaTarget.LevelId));
 
             var updatedSamplingPointQuotaTarget = new UpdateSamplingPointQuotaTarget
             {

--- a/Tests/Services/NfieldSurveysServiceTests.cs
+++ b/Tests/Services/NfieldSurveysServiceTests.cs
@@ -612,22 +612,45 @@ namespace Nfield.Services
         #region SamplingPointQuotaTargetUpdateAsync
 
         [Fact]
+        public void TestSamplingPointQuotaTargetUpdateAsync_SurveyIdArgumentIsNull_ThrowsArgumentNullException()
+        {
+            var target = new NfieldSurveysService();
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                target.SamplingPointQuotaTargetUpdateAsync(null, It.IsAny<string>(), It.IsAny<SamplingPointQuotaTarget>()).Wait();
+            });
+        }
+
+        [Fact]
+        public void TestSamplingPointQuotaTargetUpdateAsync_SamplingPointIdArgumentIsNull_ThrowsArgumentNullException()
+        {
+            var target = new NfieldSurveysService();
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                target.SamplingPointQuotaTargetUpdateAsync(It.IsAny<string>(), null, It.IsAny<SamplingPointQuotaTarget>()).Wait();
+            });
+        }
+
+        [Fact]
         public void TestSamplingPointQuotaTargetUpdateAsync_SamplingPointQuotaTargetArgumentIsNull_ThrowsArgumentNullException()
         {
             var target = new NfieldSurveysService();
-            Assert.Throws<ArgumentNullException>(
-                () =>
-                {
-                    try
-                    {
-                        target.SamplingPointQuotaTargetUpdateAsync("", "", null).Wait();
-                    }
-                    catch (AggregateException ex)
-                    {
-                        throw ex.InnerException;
-                    }
-                }
-                );
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                target.SamplingPointQuotaTargetUpdateAsync(It.IsAny<string>(), It.IsAny<string>(), null).Wait();
+            });
+        }
+
+        [Fact]
+        public void TestSamplingPointQuotaTargetUpdateAsync_SamplingPointQuotaTargetLevelIdIsNull_ThrowsArgumentNullException()
+        {
+            var target = new NfieldSurveysService();
+            var samplingPointQuotaTarget = new SamplingPointQuotaTarget{ Target = 4 };
+
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                target.SamplingPointQuotaTargetUpdateAsync(It.IsAny<string>(), It.IsAny<string>(), samplingPointQuotaTarget).Wait();
+            });
         }
 
         [Fact]


### PR DESCRIPTION
To fix the [issue 385](https://github.com/NIPOSoftwareBV/nfield/issues/385) we need to make the LevelId property public.

We also added valildation for the mandatory parameters and some unit tests for that validation.

Related:
- Actual fix for the test in nfield source: https://github.com/NIPOSoftwareBV/nfield-source/pull/2242
- Update package in glu api: https://github.com/NIPOSoftwareBV/project-glu-api/pull/1613