### PR TITLE
Give visibility to Nfield.Manager.Api.IntegrationTests

### DIFF
--- a/Library/Models/SamplingPointQuotaTarget.cs
+++ b/Library/Models/SamplingPointQuotaTarget.cs
@@ -27,7 +27,7 @@ namespace Nfield.Models
         /// The Id of the Quota Level
         /// </summary>
         [JsonProperty]
-        public string LevelId { get; set; }
+        public string LevelId { get; internal set; }
 
         /// <summary>
         /// Actual target of the level

--- a/Library/Properties/AssemblyInfo.cs
+++ b/Library/Properties/AssemblyInfo.cs
@@ -32,4 +32,5 @@ using System.Runtime.CompilerServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: InternalsVisibleTo("Nfield.SDK.Tests")]
+[assembly: InternalsVisibleTo("Nfield.Manager.Api.IntegrationTests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
Instead of making the property internal for everyone, give visibility to Nfield.Manager.Api.IntegrationTests