### PR TITLE
Add new client

### DIFF
--- a/Library/Infrastructure/ActiveDirectoryNfieldHttpClient.cs
+++ b/Library/Infrastructure/ActiveDirectoryNfieldHttpClient.cs
@@ -1,0 +1,75 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+
+using Newtonsoft.Json;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nfield.Infrastructure
+{
+    internal sealed class ActiveDirectoryNfieldHttpClient : INfieldHttpClient
+    {
+        private readonly NfieldConnection _connection;
+
+        public ActiveDirectoryNfieldHttpClient(NfieldConnection connection) => _connection = connection;
+
+        public Task<HttpResponseMessage> DeleteAsJsonAsync<TContent>(string requestUri, TContent content)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Put, requestUri) { Content = GetHttpContentForValue(content) });
+
+        public Task<HttpResponseMessage> DeleteAsync(string requestUri)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Delete, requestUri));
+
+        public Task<HttpResponseMessage> GetAsync(string requestUri)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Get, requestUri));
+
+        public Task<HttpResponseMessage> PatchAsJsonAsync<TContent>(string requestUri, TContent content)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Put, requestUri) { Content = GetHttpContentForValue(content) });
+
+        public Task<HttpResponseMessage> PostAsJsonAsync<TContent>(string requestUri, TContent content)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Put, requestUri) { Content = GetHttpContentForValue(content) });
+
+        public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Post, requestUri) { Content = content });
+
+        public Task<HttpResponseMessage> PutAsJsonAsync<TContent>(string requestUri, TContent content)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Put, requestUri) { Content = GetHttpContentForValue(content) });
+
+        public Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Put, requestUri) { Content = content });
+
+        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+        {
+            using (var client = new HttpClient())
+            {
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _connection.Token);
+                client.DefaultRequestHeaders.Add("X-Nfield-Domain", _connection.DomainName);
+
+                return client.SendAsync(request);
+            }
+        }
+
+        private HttpContent GetHttpContentForValue<TContent>(TContent content)
+        {
+            return new StringContent(
+                JsonConvert.SerializeObject(content, Formatting.None),
+                Encoding.UTF8,
+                "application/json"
+            );
+        }
+    }
+}

--- a/Library/Infrastructure/DefaultNfieldHttpClient.cs
+++ b/Library/Infrastructure/DefaultNfieldHttpClient.cs
@@ -29,12 +29,16 @@ namespace Nfield.Infrastructure
     /// A wrapper around <see cref="HttpClient"/> that also adds an authentication header to the response
     /// if it was received in the request.
     /// </summary>
-    internal sealed class NfieldHttpClient : INfieldHttpClient
+    internal sealed class DefaultNfieldHttpClient : INfieldHttpClient
     {
+        private readonly NfieldConnection _connection;
+
+        public DefaultNfieldHttpClient(NfieldConnection connection)
+        {
+            _connection = connection;
+        }
 
         #region INfieldHttpClient Members
-
-        public string AuthToken { get; set; }
 
         public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
         {
@@ -100,9 +104,9 @@ namespace Nfield.Infrastructure
             {
                 using (var client = new HttpClient())
                 {
-                    if (AuthToken != null)
+                    if (_connection.Token != null)
                     {
-                        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", AuthToken);
+                        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", _connection.Token);
                     }
 
                     var response = call(client).Result;
@@ -111,7 +115,7 @@ namespace Nfield.Infrastructure
                     if (response.Headers.TryGetValues("X-AuthenticationToken", out headerValues))
                     {
                         // auth token may have been 'null', or may have been refreshed on the server, so set it always
-                        AuthToken = headerValues.First();
+                        _connection.Token = headerValues.First();
                     }
 
                     return response.ValidateResponse();

--- a/Library/Infrastructure/INfieldConnection.cs
+++ b/Library/Infrastructure/INfieldConnection.cs
@@ -47,4 +47,9 @@ namespace Nfield.Infrastructure
 
     }
 
+    public interface INfieldConnectionV2 : INfieldConnection
+    {
+        Task SignInAsync(string domainName, string token);
+    }
+
 }

--- a/Library/Infrastructure/INfieldHttpClient.cs
+++ b/Library/Infrastructure/INfieldHttpClient.cs
@@ -13,7 +13,6 @@
 //    You should have received a copy of the GNU Lesser General Public License
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
-using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -21,8 +20,6 @@ namespace Nfield.Infrastructure
 {
     internal interface INfieldHttpClient
     {
-        
-        string AuthToken { get; set; }
         Task<HttpResponseMessage> SendAsync(HttpRequestMessage request);
         Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content);
         Task<HttpResponseMessage> GetAsync(string requestUri);

--- a/Library/Infrastructure/INfieldHttpClient.cs
+++ b/Library/Infrastructure/INfieldHttpClient.cs
@@ -13,12 +13,13 @@
 //    You should have received a copy of the GNU Lesser General Public License
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Nfield.Infrastructure
 {
-    internal interface INfieldHttpClient
+    internal interface INfieldHttpClient : IDisposable
     {
         Task<HttpResponseMessage> SendAsync(HttpRequestMessage request);
         Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content);

--- a/Library/Infrastructure/NfieldConnection.cs
+++ b/Library/Infrastructure/NfieldConnection.cs
@@ -22,12 +22,9 @@ using Nfield.Extensions;
 
 namespace Nfield.Infrastructure
 {
-    internal class NfieldConnection : INfieldConnection, INfieldConnectionClient
+    internal class NfieldConnection : INfieldConnectionV2, INfieldConnectionClient
     {
-        internal string Token { get; set; }
-        internal string DomainName { get; set; }
-
-        public INfieldHttpClient Client { get; private set; }
+        public INfieldHttpClient Client { get; internal /* for tests */ set; }
 
         #region Implementation of IServiceProvider
 
@@ -69,7 +66,7 @@ namespace Nfield.Infrastructure
         {
             if (Client == null)
             {
-                Client = new DefaultNfieldHttpClient(this);
+                Client = new DefaultNfieldHttpClient();
             }
 
             var data = new Dictionary<string, string>
@@ -79,8 +76,6 @@ namespace Nfield.Infrastructure
                     {"Password", password}
                 };
             var content = new FormUrlEncodedContent(data);
-
-            DomainName = domainName;
 
             // client will update the Token
             return Client.PostAsync(NfieldServerUri + "SignIn", content)
@@ -95,11 +90,8 @@ namespace Nfield.Infrastructure
         {
             if (Client == null)
             {
-                Client = new ActiveDirectoryNfieldHttpClient(this);
+                Client = new BearerTokenNfieldHttpClient(domainName, token);
             }
-
-            DomainName = domainName;
-            Token = token;
 
             return Task.FromResult<object>(null);
         }

--- a/Library/Infrastructure/NfieldConnectionFactory.cs
+++ b/Library/Infrastructure/NfieldConnectionFactory.cs
@@ -14,6 +14,7 @@
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Threading.Tasks;
 
 namespace Nfield.Infrastructure
 {
@@ -26,7 +27,7 @@ namespace Nfield.Infrastructure
         /// <summary>
         /// Create a connection to the Nfield server on the specified <paramref name="nfieldServerUri"/>.
         /// </summary>
-        public static INfieldConnection Create(Uri nfieldServerUri)
+        public static INfieldConnectionV2 Create(Uri nfieldServerUri)
         {
             var connection = DependencyResolver.Current.Resolve<NfieldConnection>();
             var url = nfieldServerUri.ToString().TrimEnd('/') + "/";
@@ -36,5 +37,4 @@ namespace Nfield.Infrastructure
         }
 
     }
-
 }

--- a/Library/Infrastructure/NfieldHttpClientBase.cs
+++ b/Library/Infrastructure/NfieldHttpClientBase.cs
@@ -1,0 +1,69 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using System.Text;
+
+namespace Nfield.Infrastructure
+{
+    internal abstract class NfieldHttpClientBase : INfieldHttpClient
+    {
+        protected HttpClient Client { get; }
+
+        public NfieldHttpClientBase()
+        {
+            Client = new HttpClient();
+        }
+
+        public Task<HttpResponseMessage> DeleteAsJsonAsync<TContent>(string requestUri, TContent content)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Put, requestUri) { Content = GetHttpContentForValue(content) });
+
+        public Task<HttpResponseMessage> DeleteAsync(string requestUri)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Delete, requestUri));
+
+        public Task<HttpResponseMessage> GetAsync(string requestUri)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Get, requestUri));
+
+        public Task<HttpResponseMessage> PatchAsJsonAsync<TContent>(string requestUri, TContent content)
+            => SendAsync(new HttpRequestMessage(new HttpMethod("PATCH"), requestUri) { Content = GetHttpContentForValue(content) });
+
+        public Task<HttpResponseMessage> PostAsJsonAsync<TContent>(string requestUri, TContent content)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Post, requestUri) { Content = GetHttpContentForValue(content) });
+
+        public Task<HttpResponseMessage> PostAsync(string requestUri, HttpContent content)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Post, requestUri) { Content = content });
+
+        public Task<HttpResponseMessage> PutAsJsonAsync<TContent>(string requestUri, TContent content)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Put, requestUri) { Content = GetHttpContentForValue(content) });
+
+        public Task<HttpResponseMessage> PutAsync(string requestUri, HttpContent content)
+            => SendAsync(new HttpRequestMessage(HttpMethod.Put, requestUri) { Content = content });
+
+        public abstract Task<HttpResponseMessage> SendAsync(HttpRequestMessage message);
+
+        public void Dispose() => Client.Dispose();
+
+        private HttpContent GetHttpContentForValue<TContent>(TContent content)
+        {
+            return new StringContent(
+                JsonConvert.SerializeObject(content, Formatting.None),
+                Encoding.UTF8,
+                "application/json"
+            );
+        }
+    }
+}

--- a/Library/Infrastructure/NfieldSdkInitializer.cs
+++ b/Library/Infrastructure/NfieldSdkInitializer.cs
@@ -32,6 +32,7 @@ namespace Nfield.Infrastructure
         /// <param name="registerTransient">Method that registers a Transient type.</param>
         /// <param name="registerSingleton">Method that registers a Singleton.</param>
         /// <param name="registerInstance">Method that registers an instance.</param>
+        [Obsolete("Dependency injection for Nfield Services is no longer supported. Please use NfieldConnectionClient.GetService instead.")]
         public static void Initialize(Action<Type, Type> registerTransient, 
                                       Action<Type, Type> registerSingleton,
                                       Action<Type, Object> registerInstance)
@@ -69,7 +70,7 @@ namespace Nfield.Infrastructure
             registerTransient(typeof(INfieldSurveyPublishService), typeof(NfieldSurveyPublishService));
             registerTransient(typeof(INfieldSurveySampleDataService), typeof(NfieldSurveySampleDataService));
             registerTransient(typeof(INfieldSurveySampleService), typeof(NfieldSurveySampleService));
-            registerTransient(typeof(INfieldHttpClient), typeof(NfieldHttpClient));
+            registerTransient(typeof(INfieldHttpClient), typeof(DefaultNfieldHttpClient));
             registerTransient(typeof(IFileSystem), typeof(FileSystem));
             registerTransient(typeof(INfieldEncryptionUtility), typeof(NfieldEncryptionUtility));
             registerTransient(typeof(IAesManagedWrapper), typeof(AesManagedWrapper));

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 This SDK allows you to build applications that take advantage of the Nfield services.
     
 ## Requirements
-- .NET Framework 4.0 or later.
+- .NET Framework 4.5.2 or later.
 - To use this SDK to call Nfield services you need an Nfield account.
 
 ## Usage
@@ -20,15 +20,6 @@ Alternatively get the source code of the SDK by cloning this repository and incl
 A comprehensive sample project can be found in the _Examples_ folder.
 The basic required steps are shown below.
 
-First we need to use and register a dependency resolver. In this example we're using
-[Ninject].
-```c#
-using(IKernel kernel = new StandardKernel()) {
-    DependencyResolver.Register(type => kernel.Get(type), type => kernel.GetAll(type));
-    NfieldSdkInitializer.Initialize((bind, resolve) => kernel.Bind(bind).To(resolve).InTransientScope(),
-                                    (bind, resolve) => kernel.Bind(bind).To(resolve).InSingletonScope(),
-                                    (bind, resolve) => kernel.Bind(bind).ToConstant(resolve));
-```
 Create a connection.
 ```c#
 INfieldConnection connection = NfieldConnectionFactory.Create(new Uri("https://api.nfieldmr.com/v1/"));
@@ -65,5 +56,4 @@ await _interviewersService.AddAsync(interviewer);
 For feedback related to this SDK please visit the
 [Nfield website].
 
-[Ninject]: http://www.ninject.org/
 [Nfield website]: https://www.nipo.com/

--- a/Tests/Infrastructure/NfieldConnectionTests.cs
+++ b/Tests/Infrastructure/NfieldConnectionTests.cs
@@ -28,64 +28,6 @@ namespace Nfield.Infrastructure
     /// </summary>
     public class NfieldConnectionTests
     {
-        #region SignInAsync Tests
-
-        [Fact]
-        public void TestSignInAsync_CredentialsAreIncorrect_ReturnsFalse()
-        {
-            var mockedHttpClient = new Mock<INfieldHttpClient>();
-            var mockedResolver = new Mock<IDependencyResolver>();
-            DependencyResolver.Register(mockedResolver.Object);
-            mockedResolver
-                .Setup(resolver => resolver.Resolve(typeof(INfieldHttpClient)))
-                .Returns(mockedHttpClient.Object);
-            mockedHttpClient
-                .Setup(httpClient => httpClient.PostAsync(It.IsAny<string>(), It.IsAny<HttpContent>()))
-                .Returns(CreateTask(HttpStatusCode.BadRequest));
-
-            var target = new NfieldConnection();
-            var result = target.SignInAsync("", "", "").Result;
-
-            Assert.False(result);
-        }
-
-        [Fact]
-        public void TestSignInAsync_CredentialsAreCorrect_ReturnsTrue()
-        {
-            Uri ServerUri = new Uri(@"http://localhost/");
-
-            const string Domain = "Domain";
-            const string Username = "UserName";
-            const string Password = "Password";
-
-            var mockedHttpClient = new Mock<INfieldHttpClient>();
-            var mockedResolver = new Mock<IDependencyResolver>();
-            DependencyResolver.Register(mockedResolver.Object);
-            mockedResolver
-                .Setup(resolver => resolver.Resolve(typeof(INfieldHttpClient)))
-                .Returns(mockedHttpClient.Object);
-            var content = new FormUrlEncodedContent(new Dictionary<string, string>
-                {
-                    {"Domain", Domain},
-                    {"Username", Username},
-                    {"Password", Password}
-                });
-            mockedHttpClient
-                .Setup(httpClient => httpClient.PostAsync(It.IsAny<string>(), It.IsAny<HttpContent>()))
-                .Returns(CreateTask(HttpStatusCode.BadRequest));
-            mockedHttpClient
-                .Setup(httpClient => httpClient.PostAsync(ServerUri + "SignIn", It.Is<HttpContent>(c => CheckContent(c, content))))
-                .Returns(CreateTask(HttpStatusCode.OK));
-
-            var target = new NfieldConnection();
-            target.NfieldServerUri = ServerUri;
-            var result = target.SignInAsync(Domain, Username, Password).Result;
-
-            Assert.True(result);
-        }
-
-        #endregion
-
         #region GetService Tests
 
         [Fact]

--- a/Tests/Infrastructure/NfieldSdkInitializerTests.cs
+++ b/Tests/Infrastructure/NfieldSdkInitializerTests.cs
@@ -33,7 +33,7 @@ namespace Nfield.Infrastructure
         private readonly List<Type> _interfaceList = new List<Type>();
 
         [Fact]
-        public void TestSignInAsync_CredentialsAreIncorrect_ReturnsFalse()
+        public void Test_RegistersAllTheCorrectTypes()
         {
             NfieldSdkInitializer.Initialize(RegisterTransient, RegisterSingleton, RegisterObject);
 
@@ -41,6 +41,7 @@ namespace Nfield.Infrastructure
             _interfaceList.Add(typeof(IInterviewer));
             _interfaceList.Add(typeof(IDependencyResolver));
             _interfaceList.Add(typeof(INfieldConnection));
+            _interfaceList.Add(typeof(INfieldConnectionV2));
             _interfaceList.Add(typeof(INfieldConnectionClient));
             _interfaceList.Add(typeof(INfieldConnectionClientObject));
 


### PR DESCRIPTION
This PR moves the spot where the current token is kept to the NfieldConnection, while keeping the logic for the refresh in the client.

It also introduces a new client, to be used when doing Active Directory authentication.