### PR TITLE
Upgrade System.Net.Http package

### DIFF
--- a/Library/Nfield.SDK.csproj
+++ b/Library/Nfield.SDK.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="4.0.30506" />
     <PackageReference Include="Newtonsoft.Json" Version="8.0.1" />
     <PackageReference Include="Nfield.Quota" Version="1.0.187.0" />
-    <PackageReference Include="System.Net.Http" Version="2.0.20710" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Net" />


### PR DESCRIPTION
Now that our SDK is on 4.5.2+ we should really upgrade this package as it was restricting the Microsoft.Http package to the last version supported on 4.0 which causes trouble for consumer running on higher framework versions.