### PR TITLE
Update nipo .net standard packages

### DIFF
--- a/Examples/Nfield.SDK.Samples.csproj
+++ b/Examples/Nfield.SDK.Samples.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <Authors>NIPO</Authors>
     <Company>NIPO</Company>
     <Copyright>Copyright © NIPO 2018</Copyright>

--- a/Library/Nfield.SDK.csproj
+++ b/Library/Nfield.SDK.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net452</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <Authors>NIPO</Authors>
     <Company>NIPO</Company>
     <Copyright>Copyright © NIPO 2018</Copyright>
@@ -17,8 +17,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="4.0.30506" />
-    <PackageReference Include="Newtonsoft.Json" Version="8.0.1" />
-    <PackageReference Include="Nfield.Quota" Version="1.0.187.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Nfield.Quota" Version="1.0.236-prerelease" />
     <PackageReference Include="System.Net.Http" Version="2.0.20710" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/Nfield.SDK.Tests.csproj
+++ b/Tests/Nfield.SDK.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-      <TargetFramework>net452</TargetFramework>
+      <TargetFramework>net462</TargetFramework>
       <!-- Insert the root namespace of the assembly under test below-->
       <RootNamespace>Nfield</RootNamespace>
       <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
Update the packages we changed to .NET standard:
- Nfield.Quota: https://github.com/NIPOSoftware/Nfield.Quota/pull/45

_Note_: We needed to update the target framework to 4.6.2 to be able to use .NET Standard packages.