### PR TITLE
[Story] Improve automation in SDK release

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,18 @@ await _interviewersService.AddAsync(interviewer);
 }
 ```
 
+## Versioning
+
+There is a file `version.txt` in the root of the repository containing the `major.minor` version.
+The build server will append an incrementing third digit.
+The number in this file should be increased in a sensible way every time the SDK is changed,
+using [semantic versioning](https://semver.org/).
+
+The suffixes that will be appended to the nuget package versions will be the following: 
+- no suffix for release versions
+- `-beta` for builds from master
+- `-alpha` for builds on other branches
+
 ## Feedback
 For feedback related to this SDK please visit the
 [Nfield website].

--- a/createnugetversion.ps1
+++ b/createnugetversion.ps1
@@ -23,6 +23,7 @@ if( -Not (Test-Path version.txt))
     Write-Error "version.txt does not exist"
     exit 1	
 }
+
 $VersionFormat = Get-Content version.txt | Where-Object { !$_.StartsWith("#") }
 Write-Host "VersionFormat:" $VersionFormat
 if(([regex]::Matches($VersionFormat, "\." )).count -ne 2) 
@@ -34,19 +35,19 @@ if(([regex]::Matches($VersionFormat, "\." )).count -ne 2)
 $BuildId = $env:BUILD_BUILDID
 Write-Host "BuildId:" $BuildId
 
-Write-Host "releaseversion:" $env:releaseversion
-if ($env:releaseversion -eq "true")
+if ($env:releaseId)
 {
-# releaseversion is set to true in azure function
-$Suffix = ""
+    Write-Host "Building for release" $env:releaseId
+    $Suffix = ""
 }
 else
 {
-$Branch = $env:BUILD_SOURCEBRANCHNAME
-Write-Host "Branch:" $Branch
-$Suffix = if ($Branch -eq "master") {"-beta"} else {"-alpha"}	
+    $Branch = $env:BUILD_SOURCEBRANCHNAME
+    Write-Host "Branch:" $Branch
+    $Suffix = if ($Branch -eq "master") {"-beta"} else {"-alpha"}	
+    Write-Host "Suffix:" $Suffix
 }
-Write-Host "Suffix:" $Suffix
+
 $Version = $VersionFormat.replace("{buildId}",$BuildId).replace("{suffix}",$Suffix)
 Write-Host "##vso[task.setvariable variable=Version]$Version"
 Write-Host "Version:" $Version

--- a/prerelease.ps1
+++ b/prerelease.ps1
@@ -1,7 +1,0 @@
-if ($env:APPVEYOR_REPO_BRANCH -eq "master" -and (-not $env:APPVEYOR_PULL_REQUEST_NUMBER))  {
-  Write-Host "Package will be published to NuGet"
-  $env:assembly_informational_version = $env:APPVEYOR_BUILD_VERSION
-} else {
-  Write-Host "Package will be published to NuGet as prerelease"
-  $env:assembly_informational_version =  $env:APPVEYOR_BUILD_VERSION + "-prerelease" 
-}

--- a/publish-release.ps1
+++ b/publish-release.ps1
@@ -1,0 +1,30 @@
+param(
+    [Parameter(Mandatory=$true)] $AccessToken
+)
+
+$organization = "NIPOSoftware"
+$repository = "Nfield-SDK"
+
+$Headers = @{
+    Authorization = 'Basic {0}' -f [System.Convert]::ToBase64String([char[]]($AccessToken));
+}
+
+$apiUrl = "https://api.github.com/repos/{0}/{1}/releases/{2}" -f  $organization, $repository, $env:releaseId
+$description = "Package version: " + $env:Version
+$patchBody = @{ 
+    prerelease = 'false';
+    body = $description
+} | ConvertTo-Json
+
+try
+{
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    Invoke-RestMethod -Uri $apiUrl -Method Patch -Headers $Headers -Body $patchBody
+}
+catch
+{
+    Write-Host Error when trying to publish the release: $_
+    exit 1
+}
+
+Write-Host Release $release.name published!

--- a/publish-release.ps1
+++ b/publish-release.ps1
@@ -2,6 +2,12 @@ param(
     [Parameter(Mandatory=$true)] $AccessToken
 )
 
+if (-not $env:releaseId)
+{
+    Write-Host Not a release build, done
+    exit
+}
+
 $organization = "NIPOSoftware"
 $repository = "Nfield-SDK"
 


### PR DESCRIPTION
See documentation at https://github.com/NIPOSoftwareBV/Nfield-Documentation/pull/765
Also related https://github.com/NIPOSoftwareBV/Nfield-Tools/pull/325

Changes here:
- explain versioning in readme
- removing file used in old appveyor build
- add script to be used at the end of the SDK package build to publish the github release