### PR TITLE
[Story] Support max quota targets

### DIFF
--- a/Library/Nfield.SDK.csproj
+++ b/Library/Nfield.SDK.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="Nfield.Quota" Version="3.0.61971-alpha" />
+    <PackageReference Include="Nfield.Quota" Version="3.0.62409-beta" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR is part of the feature to support max targets. Until now all our quota targets have been minimum target with the exception of overall target which indicated the maximum allowed number of interviews. In this story we extended the system so that for each quota level it is now also possible to configure the max target. This new number is optional can be mixed and matched with the existing minimum target. A big advantage of the combination of minimum and maximum target is that the user is now able to configure 'bands'.

In the past given the following frame:

| Name | Min | Max |
| --- | --- | --- |
| Target | - | 50|
| Male | 15 | - |
| Female | 25 | - |

The quota could be filled with 15 males and 35 female, but now with max targets you can the maximum variation in filling

| Name | Min | Max |
| --- | --- | --- |
| Target | - | 50|
| Male | 15 | 25 |
| Female | 25 | 30 |

With this new filling the number of the complete generated for the female quota level can be further constrained.

