### PR TITLE
Issue [#1834]: Extend API with calls for Management Tab

### DIFF
--- a/Library/Infrastructure/NfieldSdkInitializer.cs
+++ b/Library/Infrastructure/NfieldSdkInitializer.cs
@@ -33,6 +33,7 @@ namespace Nfield.Infrastructure
             { typeof(INfieldInterviewsService), typeof(NfieldInterviewsService) },
             { typeof(INfieldInterviewQualityService), typeof(NfieldInterviewQualityService) },
             { typeof(INfieldSurveysService), typeof(NfieldSurveysService) },
+            { typeof(INfieldSurveyResourcesService), typeof(NfieldSurveyResourcesService) },
             { typeof(INfieldRespondentDataEncryptService), typeof(NfieldRespondentDataEncryptService) },
             { typeof(INfieldSurveyDataService), typeof(NfieldSurveyDataService) },
             { typeof(INfieldBackgroundTasksService), typeof(NfieldBackgroundTasksService) },

--- a/Library/Models/SurveyChannel.cs
+++ b/Library/Models/SurveyChannel.cs
@@ -19,33 +19,13 @@ using Newtonsoft.Json;
 namespace Nfield.Models
 {
     /// <summary>
-    /// Holds the properties of survey resources
+    /// Survey channel
     /// </summary>
-    public class SurveyResources : SurveyBase
+    public enum SurveyChannel
     {
-        [JsonProperty]
-        public DateTime? CreationDate { get; internal set; }
-
-        [JsonProperty]
-        public string ClientName { get; internal set; }
-
-        [JsonProperty]
-        public string Owner { get; internal set; }
-
-        [JsonProperty]
-        public DateTime? LastDataDownloadDate { get; internal set; }
-
-        [JsonProperty]
-        public DateTime? LastDataCollectionDate { get; internal set; }
-
-        [JsonProperty]
-        public long? Size { get; internal set; }
-
-        [JsonProperty]
-        public SurveyChannel Channel { get; internal set; }
-
-        [JsonProperty]
-        public SurveyStatus State { get; internal set; }
-
+        Unknown,
+        Cati,
+        Online,
+        Capi,
     }
 }

--- a/Library/Models/SurveyResources.cs
+++ b/Library/Models/SurveyResources.cs
@@ -1,0 +1,39 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Nfield.Models
+{
+    /// <summary>
+    /// Holds the properties of survey resources
+    /// </summary>
+    public class SurveyResources : SurveyBase
+    {
+        public DateTime? CreationDate { get; internal set; }
+
+        public string ClientName { get; internal set; }
+
+        [JsonProperty]
+        public string Owner { get; internal set; }
+
+        public DateTime? LastDataDownloadDate { get; internal set; }
+
+        public DateTime? LastDataCollectionDate { get; internal set; }
+
+        public long? Size { get; internal set; }
+    }
+}

--- a/Library/Services/INfieldSurveyResourcesService.cs
+++ b/Library/Services/INfieldSurveyResourcesService.cs
@@ -1,0 +1,37 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Nfield.Models;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Represents a method to read survey resources data.
+    /// </summary>
+    public interface INfieldSurveyResourcesService
+    {
+        #region CRUD on Survey
+
+        /// <summary>
+        /// Gets survey resources queryable object.
+        /// </summary>
+        Task<IQueryable<SurveyResources>> QueryAsync();
+        
+        #endregion
+    }
+
+}

--- a/Library/Services/Implementation/NfieldSurveyResourcesService.cs
+++ b/Library/Services/Implementation/NfieldSurveyResourcesService.cs
@@ -1,0 +1,66 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Newtonsoft.Json;
+using Nfield.Extensions;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nfield.Services.Implementation
+{
+    /// <summary>
+    /// Implementation of <see cref="INfieldSurveyResourcesService"/>
+    /// </summary>
+    internal class NfieldSurveyResourcesService : INfieldSurveyResourcesService, INfieldConnectionClientObject
+    {
+        #region Implementation of INfieldSurveyResourcesService
+
+        private Uri SurveyResourcesApi => new Uri(ConnectionClient.NfieldServerUri, "SurveyResources/");
+
+        /// <summary>
+        /// See <see cref="INfieldSurveyResourcesService.QueryAsync"/>
+        /// </summary>
+        public Task<IQueryable<SurveyResources>> QueryAsync()
+        {
+            return Client.GetAsync(SurveyResourcesApi)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<List<SurveyResources>>(stringTask.Result).AsQueryable())
+                         .FlattenExceptions();
+        }
+        
+        #endregion
+
+        #region Implementation of INfieldConnectionClientObject
+
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        #endregion
+
+        private INfieldHttpClient Client => ConnectionClient.Client;
+    }
+  
+}

--- a/Tests/Services/NfieldSurveyResourcesServiceTests.cs
+++ b/Tests/Services/NfieldSurveyResourcesServiceTests.cs
@@ -75,7 +75,7 @@ namespace Nfield.Services
 
             for (var i = 0; i < 5; i++)
             {
-                var actualSurveyResource = actualSurveyResources.ToArray()[i];
+                var actualSurveyResource = actualSurveyResources.ElementAt(i);
                 var expectedSurveyResource = expectedSurveyResources[i];
 
                 Assert.Equal(expectedSurveyResource.SurveyId, actualSurveyResource.SurveyId);

--- a/Tests/Services/NfieldSurveyResourcesServiceTests.cs
+++ b/Tests/Services/NfieldSurveyResourcesServiceTests.cs
@@ -1,0 +1,65 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using Nfield.Services.Implementation;
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Tests for <see cref="NfieldSurveyResourcesService"/>
+    /// </summary>
+    public class NfieldSurveyResourcesServiceTests : NfieldServiceTestsBase
+    {
+        #region QueryAsync
+
+        [Fact]
+        public void TestQueryAsync_ServerReturnsQuery_ReturnsListWithSurveyResources()
+        {
+            var expectedSurveyResources = new[]
+            { new SurveyResources { Owner = "Owner1" },
+              new SurveyResources { Owner = "Owner2" },
+              new SurveyResources { Owner = "Owner3" }
+            };
+            
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+            mockedHttpClient
+                .Setup(client => client.GetAsync(new Uri(ServiceAddress, "SurveyResources/")))
+                .Returns(CreateTask(HttpStatusCode.OK, new StringContent(JsonConvert.SerializeObject(expectedSurveyResources))));
+
+            var target = new NfieldSurveyResourcesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actualSurveyResources = target.QueryAsync().Result;
+
+            Assert.Equal(expectedSurveyResources[0].Owner, actualSurveyResources.ToArray()[0].Owner);
+            Assert.Equal(expectedSurveyResources[1].Owner, actualSurveyResources.ToArray()[1].Owner);
+            Assert.Equal(expectedSurveyResources[2].Owner, actualSurveyResources.ToArray()[2].Owner);
+            Assert.Equal(3, actualSurveyResources.Count());
+        }
+
+        #endregion
+    }
+}

--- a/Tests/Services/NfieldSurveyResourcesServiceTests.cs
+++ b/Tests/Services/NfieldSurveyResourcesServiceTests.cs
@@ -36,7 +36,7 @@ namespace Nfield.Services
         #region QueryAsync
 
         [Fact]
-        public void TestQueryAsync_ServerReturnsQuery_ReturnsListWithSurveyResources()
+        public async Task TestQueryAsync_ServerReturnsQuery_ReturnsListWithSurveyResources()
         {
             var expectedSurveyResources = new List<SurveyResources>();
 
@@ -69,21 +69,24 @@ namespace Nfield.Services
             var target = new NfieldSurveyResourcesService();
             target.InitializeNfieldConnection(mockedNfieldConnection.Object);
 
-            var actualSurveyResources = target.QueryAsync().Result;
+            var actualSurveyResources = await target.QueryAsync();
 
             Assert.Equal(5, actualSurveyResources.Count());
 
             for (var i = 0; i < 5; i++)
             {
-                Assert.Equal(expectedSurveyResources[i].SurveyId, actualSurveyResources.ToArray()[i].SurveyId);
-                Assert.Equal(expectedSurveyResources[i].SurveyName, actualSurveyResources.ToArray()[i].SurveyName);
-                Assert.Equal(expectedSurveyResources[i].Owner, actualSurveyResources.ToArray()[i].Owner);
-                Assert.Equal(expectedSurveyResources[i].Size, actualSurveyResources.ToArray()[i].Size);
-                Assert.Equal(expectedSurveyResources[i].CreationDate, actualSurveyResources.ToArray()[i].CreationDate);
-                Assert.Equal(expectedSurveyResources[i].LastDataDownloadDate, actualSurveyResources.ToArray()[i].LastDataDownloadDate);
-                Assert.Equal(expectedSurveyResources[i].LastDataCollectionDate, actualSurveyResources.ToArray()[i].LastDataCollectionDate);
-                Assert.Equal(expectedSurveyResources[i].State, actualSurveyResources.ToArray()[i].State);
-                Assert.Equal(expectedSurveyResources[i].Channel, actualSurveyResources.ToArray()[i].Channel);
+                var actualSurveyResource = actualSurveyResources.ToArray()[i];
+                var expectedSurveyResource = expectedSurveyResources[i];
+
+                Assert.Equal(expectedSurveyResource.SurveyId, actualSurveyResource.SurveyId);
+                Assert.Equal(expectedSurveyResource.SurveyName, actualSurveyResource.SurveyName);
+                Assert.Equal(expectedSurveyResource.Owner, actualSurveyResource.Owner);
+                Assert.Equal(expectedSurveyResource.Size, actualSurveyResource.Size);
+                Assert.Equal(expectedSurveyResource.CreationDate, actualSurveyResource.CreationDate);
+                Assert.Equal(expectedSurveyResource.LastDataDownloadDate, actualSurveyResource.LastDataDownloadDate);
+                Assert.Equal(expectedSurveyResource.LastDataCollectionDate, actualSurveyResource.LastDataCollectionDate);
+                Assert.Equal(expectedSurveyResource.State, actualSurveyResource.State);
+                Assert.Equal(expectedSurveyResource.Channel, actualSurveyResource.Channel);
             }
         }
 


### PR DESCRIPTION
AB#60267

[Issue #1834](https://github.com/NIPOSoftwareBV/nfield/issues/1834)

New controller in the public API for retrieving all the survey resources has been created, this controller supports Odata filtering.