### PR TITLE
Issue [#1834]: Extend API with calls for Management Tab

### DIFF
--- a/Library/Infrastructure/NfieldSdkInitializer.cs
+++ b/Library/Infrastructure/NfieldSdkInitializer.cs
@@ -33,6 +33,7 @@ namespace Nfield.Infrastructure
             { typeof(INfieldInterviewsService), typeof(NfieldInterviewsService) },
             { typeof(INfieldInterviewQualityService), typeof(NfieldInterviewQualityService) },
             { typeof(INfieldSurveysService), typeof(NfieldSurveysService) },
+            { typeof(INfieldSurveyResourcesService), typeof(NfieldSurveyResourcesService) },
             { typeof(INfieldRespondentDataEncryptService), typeof(NfieldRespondentDataEncryptService) },
             { typeof(INfieldSurveyDataService), typeof(NfieldSurveyDataService) },
             { typeof(INfieldBackgroundTasksService), typeof(NfieldBackgroundTasksService) },

--- a/Library/Models/SurveyChannel.cs
+++ b/Library/Models/SurveyChannel.cs
@@ -1,0 +1,31 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Nfield.Models
+{
+    /// <summary>
+    /// Survey channel
+    /// </summary>
+    public enum SurveyChannel
+    {
+        Unknown,
+        Cati,
+        Online,
+        Capi,
+    }
+}

--- a/Library/Models/SurveyResources.cs
+++ b/Library/Models/SurveyResources.cs
@@ -21,7 +21,7 @@ namespace Nfield.Models
     /// <summary>
     /// Holds the properties of survey resources
     /// </summary>
-    public class SurveyResources : SurveyBase
+    public class SurveyResource : SurveyBase
     {
         [JsonProperty]
         public DateTime? CreationDate { get; internal set; }

--- a/Library/Models/SurveyResources.cs
+++ b/Library/Models/SurveyResources.cs
@@ -1,0 +1,51 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using Newtonsoft.Json;
+
+namespace Nfield.Models
+{
+    /// <summary>
+    /// Holds the properties of survey resources
+    /// </summary>
+    public class SurveyResources : SurveyBase
+    {
+        [JsonProperty]
+        public DateTime? CreationDate { get; internal set; }
+
+        [JsonProperty]
+        public string ClientName { get; internal set; }
+
+        [JsonProperty]
+        public string Owner { get; internal set; }
+
+        [JsonProperty]
+        public DateTime? LastDataDownloadDate { get; internal set; }
+
+        [JsonProperty]
+        public DateTime? LastDataCollectionDate { get; internal set; }
+
+        [JsonProperty]
+        public long? Size { get; internal set; }
+
+        [JsonProperty]
+        public SurveyChannel Channel { get; internal set; }
+
+        [JsonProperty]
+        public SurveyStatus State { get; internal set; }
+
+    }
+}

--- a/Library/Services/INfieldSurveyResourcesService.cs
+++ b/Library/Services/INfieldSurveyResourcesService.cs
@@ -29,7 +29,7 @@ namespace Nfield.Services
         /// <summary>
         /// Gets survey resources queryable object.
         /// </summary>
-        Task<IQueryable<SurveyResources>> QueryAsync();
+        Task<IQueryable<SurveyResource>> QueryAsync();
         
         #endregion
     }

--- a/Library/Services/INfieldSurveyResourcesService.cs
+++ b/Library/Services/INfieldSurveyResourcesService.cs
@@ -1,0 +1,37 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Nfield.Models;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Represents a method to read survey resources data.
+    /// </summary>
+    public interface INfieldSurveyResourcesService
+    {
+        #region CRUD on Survey
+
+        /// <summary>
+        /// Gets survey resources queryable object.
+        /// </summary>
+        Task<IQueryable<SurveyResources>> QueryAsync();
+        
+        #endregion
+    }
+
+}

--- a/Library/Services/Implementation/NfieldSurveyResourcesService.cs
+++ b/Library/Services/Implementation/NfieldSurveyResourcesService.cs
@@ -36,14 +36,14 @@ namespace Nfield.Services.Implementation
         /// <summary>
         /// See <see cref="INfieldSurveyResourcesService.QueryAsync"/>
         /// </summary>
-        public Task<IQueryable<SurveyResources>> QueryAsync()
+        public Task<IQueryable<SurveyResource>> QueryAsync()
         {
             return Client.GetAsync(SurveyResourcesApi)
                          .ContinueWith(
                              responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
                          .ContinueWith(
                              stringTask =>
-                             JsonConvert.DeserializeObject<List<SurveyResources>>(stringTask.Result).AsQueryable())
+                             JsonConvert.DeserializeObject<List<SurveyResource>>(stringTask.Result).AsQueryable())
                          .FlattenExceptions();
         }
         

--- a/Library/Services/Implementation/NfieldSurveyResourcesService.cs
+++ b/Library/Services/Implementation/NfieldSurveyResourcesService.cs
@@ -1,0 +1,66 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Newtonsoft.Json;
+using Nfield.Extensions;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Nfield.Services.Implementation
+{
+    /// <summary>
+    /// Implementation of <see cref="INfieldSurveyResourcesService"/>
+    /// </summary>
+    internal class NfieldSurveyResourcesService : INfieldSurveyResourcesService, INfieldConnectionClientObject
+    {
+        #region Implementation of INfieldSurveyResourcesService
+
+        private Uri SurveyResourcesApi => new Uri(ConnectionClient.NfieldServerUri, "SurveyResources/");
+
+        /// <summary>
+        /// See <see cref="INfieldSurveyResourcesService.QueryAsync"/>
+        /// </summary>
+        public Task<IQueryable<SurveyResources>> QueryAsync()
+        {
+            return Client.GetAsync(SurveyResourcesApi)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<List<SurveyResources>>(stringTask.Result).AsQueryable())
+                         .FlattenExceptions();
+        }
+        
+        #endregion
+
+        #region Implementation of INfieldConnectionClientObject
+
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        #endregion
+
+        private INfieldHttpClient Client => ConnectionClient.Client;
+    }
+  
+}

--- a/Tests/Services/NfieldSurveyResourcesServiceTests.cs
+++ b/Tests/Services/NfieldSurveyResourcesServiceTests.cs
@@ -38,11 +38,11 @@ namespace Nfield.Services
         [Fact]
         public async Task TestQueryAsync_ServerReturnsQuery_ReturnsListWithSurveyResources()
         {
-            var expectedSurveyResources = new List<SurveyResources>();
+            var expectedSurveyResources = new List<SurveyResource>();
 
             for (var i = 0; i < 5; i++)
             {
-                var surveyResource = new SurveyResources
+                var surveyResource = new SurveyResource
                 {
                     SurveyId = Guid.NewGuid().ToString(),
                     SurveyName = $"Survey{i}",

--- a/Tests/Services/NfieldSurveyResourcesServiceTests.cs
+++ b/Tests/Services/NfieldSurveyResourcesServiceTests.cs
@@ -1,0 +1,95 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using Nfield.Services.Implementation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Tests for <see cref="NfieldSurveyResourcesService"/>
+    /// </summary>
+    public class NfieldSurveyResourcesServiceTests : NfieldServiceTestsBase
+    {
+        #region QueryAsync
+
+        [Fact]
+        public async Task TestQueryAsync_ServerReturnsQuery_ReturnsListWithSurveyResources()
+        {
+            var expectedSurveyResources = new List<SurveyResources>();
+
+            for (var i = 0; i < 5; i++)
+            {
+                var surveyResource = new SurveyResources
+                {
+                    SurveyId = Guid.NewGuid().ToString(),
+                    SurveyName = $"Survey{i}",
+                    Owner = $"Owner{i}",
+                    ClientName = $"Client{i}",
+                    Size = i,
+                    CreationDate = new DateTime(2020, 1, 1),
+                    LastDataDownloadDate = new DateTime(2020,1,2),
+                    LastDataCollectionDate = new DateTime(2020, 1, 3),
+                    State = SurveyStatus.UnderConstruction,
+                    Channel = SurveyChannel.Online
+                };
+
+                expectedSurveyResources.Add(surveyResource);
+            }
+            
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+            mockedHttpClient
+                .Setup(client => client.GetAsync(new Uri(ServiceAddress, "SurveyResources/")))
+                .Returns(CreateTask(HttpStatusCode.OK,
+                    new StringContent(JsonConvert.SerializeObject(expectedSurveyResources))));
+
+            var target = new NfieldSurveyResourcesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actualSurveyResources = await target.QueryAsync();
+
+            Assert.Equal(5, actualSurveyResources.Count());
+
+            for (var i = 0; i < 5; i++)
+            {
+                var actualSurveyResource = actualSurveyResources.ElementAt(i);
+                var expectedSurveyResource = expectedSurveyResources[i];
+
+                Assert.Equal(expectedSurveyResource.SurveyId, actualSurveyResource.SurveyId);
+                Assert.Equal(expectedSurveyResource.SurveyName, actualSurveyResource.SurveyName);
+                Assert.Equal(expectedSurveyResource.Owner, actualSurveyResource.Owner);
+                Assert.Equal(expectedSurveyResource.Size, actualSurveyResource.Size);
+                Assert.Equal(expectedSurveyResource.CreationDate, actualSurveyResource.CreationDate);
+                Assert.Equal(expectedSurveyResource.LastDataDownloadDate, actualSurveyResource.LastDataDownloadDate);
+                Assert.Equal(expectedSurveyResource.LastDataCollectionDate, actualSurveyResource.LastDataCollectionDate);
+                Assert.Equal(expectedSurveyResource.State, actualSurveyResource.State);
+                Assert.Equal(expectedSurveyResource.Channel, actualSurveyResource.Channel);
+            }
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
[AB#60267](https://niposoftware.visualstudio.com/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/60267)

[Issue #1834](https://github.com/NIPOSoftwareBV/nfield/issues/1834)

New controller in the public API for retrieving all the survey resources has been created, this controller supports Odata filtering.