### PR TITLE
[Story] Extend download (filter by Etag and include VAR file) (#66561)

### DIFF
--- a/Examples/Program.cs
+++ b/Examples/Program.cs
@@ -172,11 +172,13 @@ namespace Nfield.SDK.Samples
                 DownloadSuspendedLiveInterviewData = false,
                 DownloadCapturedMedia = false,
                 DownloadParaData = false,
+                DownloadVarFile = false,
                 DownloadTestInterviewData = true,
                 DownloadFileName = "MyFileName",
                 StartDate = DateTime.Today.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture), // UTC time start of today
                 EndDate = DateTime.Today.AddDays(1).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ", CultureInfo.InvariantCulture), // UTC time end of today
-                SurveyId = "SomeSurveyId"
+                SurveyId = "SomeSurveyId",
+                SurveyVersion = 637242848690284790 // If the SurveyVersion (Etag) is specified only the surveys matching this version will be downloaded
             };
 
             var task = surveyDataService.PostAsync(myRequest).Result;

--- a/Library/Models/SurveyDownloadDataRequest.cs
+++ b/Library/Models/SurveyDownloadDataRequest.cs
@@ -79,6 +79,11 @@ namespace Nfield.Models
         public bool DownloadOpenAnswerData { get; set; }
 
         /// <summary>
+        /// Download the variables file for the interviews
+        /// </summary>
+        public bool DownloadVarFile { get; set; }
+
+        /// <summary>
         /// The name specified by the user for the download file name
         /// </summary>
         public string DownloadFileName { get; set; }
@@ -94,5 +99,11 @@ namespace Nfield.Models
         /// May be null or empty if no end date is specified.
         /// </summary>
         public string EndDate { get; set; }
+
+        /// <summary>
+        /// The survey version (Etag)
+        /// May be null or 0 if no survey version is specified.
+        /// </summary>
+        public long? SurveyVersion { get; set; }
     }
 }


### PR DESCRIPTION
[AB#66561](https://niposoftware.visualstudio.com/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/66561)

This is part of the feature [Download data for a specific version of the survey](https://github.com/NIPOSoftwareBV/Nfield-Documentation/blob/master/features/Download-Data-For-Specific-Survey-Version/grooming-notes.md)

- Update SurveyDownloadDataRequest model
- Update example, filtering sample data download with the SurveyVersion