### PR TITLE
Versioned quota through public API

### DIFF
--- a/Library/Infrastructure/NfieldSdkInitializer.cs
+++ b/Library/Infrastructure/NfieldSdkInitializer.cs
@@ -13,6 +13,7 @@
 //    You should have received a copy of the GNU Lesser General Public License
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
+using Nfield.SDK.Services.Implementation;
 using Nfield.Services;
 using Nfield.Services.Implementation;
 using Nfield.Utilities;
@@ -75,7 +76,8 @@ namespace Nfield.Infrastructure
             { typeof(INfieldExternalApisLogService), typeof(NfieldExternalApisLogService) },
             { typeof(INfieldLocalUserService), typeof(NfieldLocalUserService) },
             { typeof(INfieldCatiInterviewersService), typeof(NfieldCatiInterviewersService) },
-            { typeof(INfieldSurveyVersionsService), typeof(NfieldSurveyVersionsService) }
+            { typeof(INfieldSurveyVersionsService), typeof(NfieldSurveyVersionsService) },
+            { typeof(INfieldQuotaService), typeof(NfieldQuotaService) }
         };
 
         /// <summary>

--- a/Library/Models/QuotaFrame.cs
+++ b/Library/Models/QuotaFrame.cs
@@ -14,30 +14,32 @@
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Nfield.Models;
-using Nfield.SDK.Models;
 
-namespace Nfield.Services
+namespace Nfield.SDK.Models
 {
     /// <summary>
-    /// Represents a set of methods to read survey quota.
+    /// Represents survey quota frame.
     /// </summary>
-    public interface INfieldQuotaService
+    public class QuotaFrame
     {
         /// <summary>
-        /// Gets the quota definition for an online survey
+        /// The unique identifier of the quota frame
         /// </summary>
-        /// <param name="surveyId">The survey id</param>
-        /// <returns></returns>
-        Task<IEnumerable<QuotaFrameVersion>> GetQuotaFrameVersionsAsync(string surveyId);
+        public string Id { get; set; }
 
         /// <summary>
-        /// Gets the specified version of the quota frame  
+        /// Collection of quota frame variables
         /// </summary>
-        /// <param name="surveyId">The survey id</param>
-        /// <param name="eTag">The version of the quota frame to retrieve</param>
-        /// <returns></returns>
-        Task<QuotaFrame> GetQuotaFrameAsync(string surveyId, long eTag);
+        public IEnumerable<QuotaFrameVariable> Variables { get; set; }
+
+        /// <summary>
+        /// Quota target
+        /// </summary>
+        public int? Target { get; set; }
+
+        /// <summary>
+        /// Successful count
+        /// </summary>
+        public int Successful { get; set; }
     }
 }

--- a/Library/Models/QuotaFrameLevel.cs
+++ b/Library/Models/QuotaFrameLevel.cs
@@ -13,31 +13,49 @@
 //    You should have received a copy of the GNU Lesser General Public License
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Nfield.Models;
-using Nfield.SDK.Models;
 
-namespace Nfield.Services
+namespace Nfield.SDK.Models
 {
     /// <summary>
-    /// Represents a set of methods to read survey quota.
+    /// Represents the quota frame level
     /// </summary>
-    public interface INfieldQuotaService
+    public class QuotaFrameLevel
     {
         /// <summary>
-        /// Gets the quota definition for an online survey
-        /// </summary>
-        /// <param name="surveyId">The survey id</param>
-        /// <returns></returns>
-        Task<IEnumerable<QuotaFrameVersion>> GetQuotaFrameVersionsAsync(string surveyId);
+        /// The unique identifier of the level
+        /// </summary>    
+        public Guid Id { get; set; }
 
         /// <summary>
-        /// Gets the specified version of the quota frame  
+        /// The level name
         /// </summary>
-        /// <param name="surveyId">The survey id</param>
-        /// <param name="eTag">The version of the quota frame to retrieve</param>
-        /// <returns></returns>
-        Task<QuotaFrame> GetQuotaFrameAsync(string surveyId, long eTag);
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Collection of variables
+        /// </summary>
+        public IEnumerable<QuotaFrameVariable> Variables { get; set; }
+
+        /// <summary>
+        /// Level target
+        /// </summary>
+        public int? Target { get; set; }
+
+        /// <summary>
+        /// Level maximum target
+        /// </summary>
+        public int? MaxTarget { get; set; }
+
+        /// <summary>
+        /// Level maximum overshoot
+        /// </summary>
+        public int? MaxOvershoot { get; set; }
+
+        /// <summary>
+        /// Successful count
+        /// </summary>
+        public int Successful { get; set; }
     }
 }

--- a/Library/Models/QuotaFrameLevelTarget.cs
+++ b/Library/Models/QuotaFrameLevelTarget.cs
@@ -1,0 +1,25 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.Models
+{
+    public class QuotaFrameLevelTarget
+    {
+        public string Id { get; set; }
+        public int? Target { get; set; }
+        public int? MaxTarget { get; set; }
+        public int? MaxOvershoot { get; set; }
+    }
+}

--- a/Library/Models/QuotaFrameVariable.cs
+++ b/Library/Models/QuotaFrameVariable.cs
@@ -13,31 +13,34 @@
 //    You should have received a copy of the GNU Lesser General Public License
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using Nfield.Models;
-using Nfield.SDK.Models;
 
-namespace Nfield.Services
+namespace Nfield.SDK.Models
 {
     /// <summary>
-    /// Represents a set of methods to read survey quota.
+    /// Represents the quota frame variable
     /// </summary>
-    public interface INfieldQuotaService
+    public class QuotaFrameVariable
     {
         /// <summary>
-        /// Gets the quota definition for an online survey
-        /// </summary>
-        /// <param name="surveyId">The survey id</param>
-        /// <returns></returns>
-        Task<IEnumerable<QuotaFrameVersion>> GetQuotaFrameVersionsAsync(string surveyId);
+        /// The unique identifier of the variable
+        /// </summary>        
+        public Guid Id { get; set; }
 
         /// <summary>
-        /// Gets the specified version of the quota frame  
+        /// The variable name
         /// </summary>
-        /// <param name="surveyId">The survey id</param>
-        /// <param name="eTag">The version of the quota frame to retrieve</param>
-        /// <returns></returns>
-        Task<QuotaFrame> GetQuotaFrameAsync(string surveyId, long eTag);
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Indication if it's a multi variable
+        /// </summary>
+        public bool IsMulti { get; set; }
+
+        /// <summary>
+        /// Collection of levels
+        /// </summary>
+        public IEnumerable<QuotaFrameLevel> Levels { get; set; }
     }
 }

--- a/Library/Models/QuotaFrameVersion.cs
+++ b/Library/Models/QuotaFrameVersion.cs
@@ -1,0 +1,42 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Newtonsoft.Json;
+using System;
+
+namespace Nfield.Models
+{
+    /// <summary>
+    /// This model is used to query survey quota frame versions.
+    /// </summary>
+    public class QuotaFrameVersion
+    {
+        /// <summary>
+        /// The unique identifier for a quota frame version
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The version of the quota frame
+        /// </summary>
+        [JsonProperty(PropertyName = "eTag")]
+        public string Etag { get; set; }
+
+        /// <summary>
+        /// The timestamp for when the quota frame was published
+        /// </summary>
+        public DateTime PublishedDate { get; set; }
+    }
+}

--- a/Library/Models/QuotaFrameVersion.cs
+++ b/Library/Models/QuotaFrameVersion.cs
@@ -32,7 +32,7 @@ namespace Nfield.Models
         /// The version of the quota frame
         /// </summary>
         [JsonProperty(PropertyName = "eTag")]
-        public string Etag { get; set; }
+        public string ETag { get; set; }
 
         /// <summary>
         /// The timestamp for when the quota frame was published

--- a/Library/Services/INfieldQuotaService.cs
+++ b/Library/Services/INfieldQuotaService.cs
@@ -33,6 +33,13 @@ namespace Nfield.Services
         Task<IEnumerable<QuotaFrameVersion>> GetQuotaFrameVersionsAsync(string surveyId);
 
         /// <summary>
+        /// Updates the survey quota targets for the specified quota frame version
+        /// </summary>
+        /// <param name="surveyId">The survey to set the quota targets for</param>
+        /// <param name="quotaETag">The quota frame version to set the targets for</param>
+        /// <param name="targets">The new quota frame targets</param>
+        Task UpdateQuotaTargetsAsync(string surveyId, string quotaETag, IEnumerable<QuotaFrameLevelTarget> targets);
+
         /// Gets the specified version of the quota frame  
         /// </summary>
         /// <param name="surveyId">The survey id</param>

--- a/Library/Services/INfieldQuotaService.cs
+++ b/Library/Services/INfieldQuotaService.cs
@@ -1,0 +1,34 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Nfield.Models;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Represents a set of methods to read and update survey quota.
+    /// </summary>
+    public interface INfieldQuotaService
+    {
+        /// <summary>
+        /// Get the quota definition for an online survey
+        /// </summary>
+        /// <param name="surveyId"></param>
+        /// <returns></returns>
+        Task<IEnumerable<QuotaFrameVersion>> GetQuotaFrameVersionsAsync(string surveyId);
+    }
+}

--- a/Library/Services/INfieldQuotaService.cs
+++ b/Library/Services/INfieldQuotaService.cs
@@ -29,22 +29,21 @@ namespace Nfield.Services
         /// Gets the quota definition for an online survey
         /// </summary>
         /// <param name="surveyId">The survey id</param>
-        /// <returns></returns>
         Task<IEnumerable<QuotaFrameVersion>> GetQuotaFrameVersionsAsync(string surveyId);
 
         /// <summary>
         /// Updates the survey quota targets for the specified quota frame version
         /// </summary>
         /// <param name="surveyId">The survey to set the quota targets for</param>
-        /// <param name="quotaETag">The quota frame version to set the targets for</param>
+        /// <param name="eTag">The quota frame version to set the targets for</param>
         /// <param name="targets">The new quota frame targets</param>
-        Task UpdateQuotaTargetsAsync(string surveyId, string quotaETag, IEnumerable<QuotaFrameLevelTarget> targets);
+        Task UpdateQuotaTargetsAsync(string surveyId, string eTag, IEnumerable<QuotaFrameLevelTarget> targets);
 
+        /// <summary>
         /// Gets the specified version of the quota frame  
         /// </summary>
         /// <param name="surveyId">The survey id</param>
         /// <param name="eTag">The version of the quota frame to retrieve</param>
-        /// <returns></returns>
-        Task<QuotaFrame> GetQuotaFrameAsync(string surveyId, long eTag);
+        Task<QuotaFrame> GetQuotaFrameAsync(string surveyId, string eTag);
     }
 }

--- a/Library/Services/Implementation/NfieldQuotaService.cs
+++ b/Library/Services/Implementation/NfieldQuotaService.cs
@@ -1,0 +1,58 @@
+﻿using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using Nfield.Services;
+using Nfield.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nfield.SDK.Services.Implementation
+{
+    internal class NfieldQuotaService : INfieldQuotaService, INfieldConnectionClientObject
+    {
+        #region Implementation of INfieldConnectionClientObject
+
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        #endregion
+
+        #region Implementation of INfieldQuotaService
+
+        public Task<IEnumerable<QuotaFrameVersion>> GetQuotaFrameVersionsAsync(string surveyId)
+        {
+            ValidateParams(surveyId);
+
+            return Client.GetAsync(QuotaFrameVersionsApi(surveyId))
+                         .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(task => JsonConvert.DeserializeObject<IEnumerable<QuotaFrameVersion>>(task.Result))
+                         .FlattenExceptions();
+        }
+
+        #endregion
+        private INfieldHttpClient Client
+        {
+            get { return ConnectionClient.Client; }
+        }
+
+        private Uri QuotaFrameVersionsApi(string surveyId)
+        {
+            return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/QuotaVersions");
+        }
+
+        private static void ValidateParams(string surveyId)
+        {
+            if (surveyId == null)
+                throw new ArgumentNullException(nameof(surveyId));
+
+            if (surveyId.Trim().Length == 0)
+                throw new ArgumentException("surveyId cannot be empty");
+        }
+    }
+}

--- a/Library/Services/Implementation/NfieldQuotaService.cs
+++ b/Library/Services/Implementation/NfieldQuotaService.cs
@@ -30,7 +30,7 @@ namespace Nfield.SDK.Services.Implementation
         /// </summary>
         public Task<IEnumerable<QuotaFrameVersion>> GetQuotaFrameVersionsAsync(string surveyId)
         {
-            ValidateSurveyId(surveyId);
+            ValidateParams(surveyId);
 
             return Client.GetAsync(QuotaFrameVersionsUri(surveyId))
                          .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
@@ -39,11 +39,22 @@ namespace Nfield.SDK.Services.Implementation
         }
 
         /// <summary>
+        /// See <see cref="INfieldQuotaService.UpdateQuotaTargetsAsync"/>
+        /// </summary>
+        public Task UpdateQuotaTargetsAsync(string surveyId, string quotaETag, IEnumerable<QuotaFrameLevelTarget> targets)
+        {
+            ValidateParams(surveyId);
+
+            return Client.PutAsJsonAsync(EditingQuotaFrameTargetsUri(surveyId, quotaETag), targets)
+                         .FlattenExceptions();
+        }
+
+        /// <summary>
         /// See <see cref="INfieldQuotaService.GetQuotaFrameAsync"/>
         /// </summary>
         public Task<QuotaFrame> GetQuotaFrameAsync(string surveyId, long eTag)
         {
-            ValidateSurveyId(surveyId);
+            ValidateParams(surveyId);
 
             return Client.GetAsync(QuotaFrameUri(surveyId, eTag))
              .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
@@ -62,12 +73,17 @@ namespace Nfield.SDK.Services.Implementation
             return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/QuotaVersions");
         }
 
+        private Uri EditingQuotaFrameTargetsUri(string surveyId, string version)
+        {
+            return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/QuotaVersions/{version}/QuotaTargets");
+        }
+
         private Uri QuotaFrameUri(string surveyId, long eTag)
         {
             return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/QuotaVersions/{eTag}");
         }
 
-        private static void ValidateSurveyId(string surveyId)
+        private static void ValidateParams(string surveyId)
         {
             if (surveyId == null)
                 throw new ArgumentNullException(nameof(surveyId));

--- a/Library/Services/Implementation/NfieldQuotaService.cs
+++ b/Library/Services/Implementation/NfieldQuotaService.cs
@@ -1,5 +1,4 @@
 ﻿using Newtonsoft.Json;
-using Nfield.Extensions;
 using Nfield.Infrastructure;
 using Nfield.Models;
 using Nfield.SDK.Models;
@@ -28,38 +27,39 @@ namespace Nfield.SDK.Services.Implementation
         /// <summary>
         /// See <see cref="INfieldQuotaService.GetQuotaFrameVersionsAsync"/>
         /// </summary>
-        public Task<IEnumerable<QuotaFrameVersion>> GetQuotaFrameVersionsAsync(string surveyId)
+        public async Task<IEnumerable<QuotaFrameVersion>> GetQuotaFrameVersionsAsync(string surveyId)
         {
             ValidateSurveyId(surveyId);
 
-            return Client.GetAsync(QuotaFrameVersionsUri(surveyId))
-                         .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
-                         .ContinueWith(task => JsonConvert.DeserializeObject<IEnumerable<QuotaFrameVersion>>(task.Result))
-                         .FlattenExceptions();
+            var result = await Client.GetAsync(QuotaFrameVersionsUri(surveyId)).ConfigureAwait(false);
+
+            var content = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            return JsonConvert.DeserializeObject<IEnumerable<QuotaFrameVersion>>(content);
         }
 
         /// <summary>
         /// See <see cref="INfieldQuotaService.UpdateQuotaTargetsAsync"/>
         /// </summary>
-        public Task UpdateQuotaTargetsAsync(string surveyId, string eTag, IEnumerable<QuotaFrameLevelTarget> targets)
+        public async Task UpdateQuotaTargetsAsync(string surveyId, string eTag, IEnumerable<QuotaFrameLevelTarget> targets)
         {
             ValidateSurveyId(surveyId);
 
-            return Client.PutAsJsonAsync(QuotaFrameTargetsUri(surveyId, eTag), targets)
-                         .FlattenExceptions();
+            await Client.PutAsJsonAsync(QuotaFrameTargetsUri(surveyId, eTag), targets).ConfigureAwait(false);
         }
 
         /// <summary>
         /// See <see cref="INfieldQuotaService.GetQuotaFrameAsync"/>
         /// </summary>
-        public Task<QuotaFrame> GetQuotaFrameAsync(string surveyId, string eTag)
+        public async Task<QuotaFrame> GetQuotaFrameAsync(string surveyId, string eTag)
         {
             ValidateSurveyId(surveyId);
 
-            return Client.GetAsync(QuotaFrameUri(surveyId, eTag))
-             .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
-             .ContinueWith(task => JsonConvert.DeserializeObject<QuotaFrame>(task.Result))
-             .FlattenExceptions();
+            var result = await Client.GetAsync(QuotaFrameUri(surveyId, eTag)).ConfigureAwait(false);
+
+            var content = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            return JsonConvert.DeserializeObject<QuotaFrame>(content);
         }
 
         #endregion

--- a/Library/Services/Implementation/NfieldQuotaService.cs
+++ b/Library/Services/Implementation/NfieldQuotaService.cs
@@ -30,7 +30,7 @@ namespace Nfield.SDK.Services.Implementation
         /// </summary>
         public Task<IEnumerable<QuotaFrameVersion>> GetQuotaFrameVersionsAsync(string surveyId)
         {
-            ValidateParams(surveyId);
+            ValidateSurveyId(surveyId);
 
             return Client.GetAsync(QuotaFrameVersionsUri(surveyId))
                          .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
@@ -41,20 +41,20 @@ namespace Nfield.SDK.Services.Implementation
         /// <summary>
         /// See <see cref="INfieldQuotaService.UpdateQuotaTargetsAsync"/>
         /// </summary>
-        public Task UpdateQuotaTargetsAsync(string surveyId, string quotaETag, IEnumerable<QuotaFrameLevelTarget> targets)
+        public Task UpdateQuotaTargetsAsync(string surveyId, string eTag, IEnumerable<QuotaFrameLevelTarget> targets)
         {
-            ValidateParams(surveyId);
+            ValidateSurveyId(surveyId);
 
-            return Client.PutAsJsonAsync(EditingQuotaFrameTargetsUri(surveyId, quotaETag), targets)
+            return Client.PutAsJsonAsync(EditingQuotaFrameTargetsUri(surveyId, eTag), targets)
                          .FlattenExceptions();
         }
 
         /// <summary>
         /// See <see cref="INfieldQuotaService.GetQuotaFrameAsync"/>
         /// </summary>
-        public Task<QuotaFrame> GetQuotaFrameAsync(string surveyId, long eTag)
+        public Task<QuotaFrame> GetQuotaFrameAsync(string surveyId, string eTag)
         {
-            ValidateParams(surveyId);
+            ValidateSurveyId(surveyId);
 
             return Client.GetAsync(QuotaFrameUri(surveyId, eTag))
              .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
@@ -73,17 +73,17 @@ namespace Nfield.SDK.Services.Implementation
             return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/QuotaVersions");
         }
 
-        private Uri EditingQuotaFrameTargetsUri(string surveyId, string version)
+        private Uri EditingQuotaFrameTargetsUri(string surveyId, string eTag)
         {
-            return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/QuotaVersions/{version}/QuotaTargets");
+            return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/QuotaVersions/{eTag}/QuotaTargets");
         }
 
-        private Uri QuotaFrameUri(string surveyId, long eTag)
+        private Uri QuotaFrameUri(string surveyId, string eTag)
         {
             return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/QuotaVersions/{eTag}");
         }
 
-        private static void ValidateParams(string surveyId)
+        private static void ValidateSurveyId(string surveyId)
         {
             if (surveyId == null)
                 throw new ArgumentNullException(nameof(surveyId));

--- a/Library/Services/Implementation/NfieldQuotaService.cs
+++ b/Library/Services/Implementation/NfieldQuotaService.cs
@@ -45,7 +45,7 @@ namespace Nfield.SDK.Services.Implementation
         {
             ValidateSurveyId(surveyId);
 
-            return Client.PutAsJsonAsync(EditingQuotaFrameTargetsUri(surveyId, eTag), targets)
+            return Client.PutAsJsonAsync(QuotaFrameTargetsUri(surveyId, eTag), targets)
                          .FlattenExceptions();
         }
 
@@ -73,9 +73,9 @@ namespace Nfield.SDK.Services.Implementation
             return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/QuotaVersions");
         }
 
-        private Uri EditingQuotaFrameTargetsUri(string surveyId, string eTag)
+        private Uri QuotaFrameTargetsUri(string surveyId, string eTag)
         {
-            return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/QuotaVersions/{eTag}/QuotaTargets");
+            return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/Quota/{eTag}");
         }
 
         private Uri QuotaFrameUri(string surveyId, string eTag)

--- a/Tests/Services/NfieldQuotaServiceTests.cs
+++ b/Tests/Services/NfieldQuotaServiceTests.cs
@@ -61,11 +61,11 @@ namespace Nfield.Services
             {
                 new QuotaFrameVersion
                 {
-                    Etag = "637235755520645294"
+                    ETag = "637235755520645294"
                 },
                 new QuotaFrameVersion
                 {
-                    Etag = "637244319282906584"
+                    ETag = "637244319282906584"
                 }
             }.ToArray();
 
@@ -81,8 +81,8 @@ namespace Nfield.Services
 
             var actual = target.GetQuotaFrameVersionsAsync(SurveyId).Result.ToArray();
 
-            Assert.Equal(expectedVersions[0].Etag, actual[0].Etag);
-            Assert.Equal(expectedVersions[1].Etag, actual[1].Etag);
+            Assert.Equal(expectedVersions[0].ETag, actual[0].ETag);
+            Assert.Equal(expectedVersions[1].ETag, actual[1].ETag);
         }
 
         #endregion
@@ -111,20 +111,20 @@ namespace Nfield.Services
         public void Test_GetQuotaFrameAsync_SurveyIdIsNull_Throws()
         {
             var target = new NfieldQuotaService();
-            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(target.GetQuotaFrameAsync(null, 1)));
+            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(target.GetQuotaFrameAsync(null, "1")));
         }
 
         [Fact]
         public void Test_GetQuotaFrameAsync_SurveyIdIsEmpty_Throws()
         {
             var target = new NfieldQuotaService();
-            Assert.Throws<ArgumentException>(() => UnwrapAggregateException(target.GetQuotaFrameAsync(string.Empty, 1)));
+            Assert.Throws<ArgumentException>(() => UnwrapAggregateException(target.GetQuotaFrameAsync(string.Empty, "1")));
         }
 
         [Fact]
         public void Test_GetQuotaFrameAsync_ReturnsQuotaFrame()
         {
-            const long quotaVersion = 3;
+            const string quotaVersion = "3";
             var expecteQuotaFrame = new QuotaFrame
             {
                 Id = "frameId",

--- a/Tests/Services/NfieldQuotaServiceTests.cs
+++ b/Tests/Services/NfieldQuotaServiceTests.cs
@@ -1,0 +1,87 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using Nfield.SDK.Services.Implementation;
+using Nfield.Services.Implementation;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using Xunit;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Tests for <see cref="NfieldSurveyVersionsService"/>
+    /// </summary>
+    public class NfieldQuotaServiceTests : NfieldServiceTestsBase
+    {
+        private const string SurveyId = "SurveyId";
+
+        #region GetQuotaFrameVersionsAsync
+
+        [Fact]
+        public void Test_GetQuotaFrameVersionsAsync_SurveyIdIsNull_Throws()
+        {
+            var target = new NfieldQuotaService();
+            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(target.GetQuotaFrameVersionsAsync(null)));
+        }
+
+        [Fact]
+        public void Test_GetQuotaFrameVersionsAsync_SurveyIdIsEmpty_Throws()
+        {
+            var target = new NfieldQuotaService();
+            Assert.Throws<ArgumentException>(() => UnwrapAggregateException(target.GetQuotaFrameVersionsAsync(string.Empty)));
+        }
+
+        [Fact]
+        public void Test_GetQuotaFrameVersionsAsync_ReturnsQuotaVersions()
+        {
+            var expectedVersions = new List<QuotaFrameVersion>
+            {
+                new QuotaFrameVersion
+                {
+                    Etag = "637235755520645294"
+                },
+                new QuotaFrameVersion
+                {
+                    Etag = "637244319282906584"
+                }
+            }.ToArray();
+
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(new Uri(ServiceAddress, "Surveys/" + SurveyId + "/QuotaVersions")))
+                .Returns(CreateTask(HttpStatusCode.OK, new StringContent(JsonConvert.SerializeObject(expectedVersions))));
+
+            var target = new NfieldQuotaService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = target.GetQuotaFrameVersionsAsync(SurveyId).Result.ToArray();
+
+            Assert.Equal(expectedVersions[0].Etag, actual[0].Etag);
+            Assert.Equal(expectedVersions[1].Etag, actual[1].Etag);
+        }
+
+        #endregion
+    }
+}

--- a/Tests/Services/NfieldQuotaServiceTests.cs
+++ b/Tests/Services/NfieldQuotaServiceTests.cs
@@ -17,6 +17,7 @@ using Moq;
 using Newtonsoft.Json;
 using Nfield.Infrastructure;
 using Nfield.Models;
+using Nfield.SDK.Models;
 using Nfield.SDK.Services.Implementation;
 using Nfield.Services.Implementation;
 using System;
@@ -80,6 +81,50 @@ namespace Nfield.Services
 
             Assert.Equal(expectedVersions[0].Etag, actual[0].Etag);
             Assert.Equal(expectedVersions[1].Etag, actual[1].Etag);
+        }
+
+        #endregion
+
+        #region GetQuotaFrameAsync
+
+        [Fact]
+        public void Test_GetQuotaFrameAsync_SurveyIdIsNull_Throws()
+        {
+            var target = new NfieldQuotaService();
+            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(target.GetQuotaFrameAsync(null, 1)));
+        }
+
+        [Fact]
+        public void Test_GetQuotaFrameAsync_SurveyIdIsEmpty_Throws()
+        {
+            var target = new NfieldQuotaService();
+            Assert.Throws<ArgumentException>(() => UnwrapAggregateException(target.GetQuotaFrameAsync(string.Empty, 1)));
+        }
+
+        [Fact]
+        public void Test_GetQuotaFrameAsync_ReturnsQuotaFrame()
+        {
+            const long quotaVersion = 3;
+            var expecteQuotaFrame = new QuotaFrame
+            {
+                Id = "frameId",
+                Target = 100
+            };
+
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(new Uri(ServiceAddress, "Surveys/" + SurveyId + "/QuotaVersions/" + quotaVersion)))
+                .Returns(CreateTask(HttpStatusCode.OK, new StringContent(JsonConvert.SerializeObject(expecteQuotaFrame))));
+
+            var target = new NfieldQuotaService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = target.GetQuotaFrameAsync(SurveyId, quotaVersion).Result;
+
+            Assert.Equal(expecteQuotaFrame.Id, actual.Id);
+            Assert.Equal(expecteQuotaFrame.Target, actual.Target);
         }
 
         #endregion

--- a/Tests/Services/NfieldQuotaServiceTests.cs
+++ b/Tests/Services/NfieldQuotaServiceTests.cs
@@ -35,6 +35,8 @@ namespace Nfield.Services
     public class NfieldQuotaServiceTests : NfieldServiceTestsBase
     {
         private const string SurveyId = "SurveyId";
+        private List<QuotaFrameLevelTarget> quotaFrameTargets = new List<QuotaFrameLevelTarget>();
+        private string quotaETag = "637235755520645297";
 
         #region GetQuotaFrameVersionsAsync
 
@@ -81,6 +83,24 @@ namespace Nfield.Services
 
             Assert.Equal(expectedVersions[0].Etag, actual[0].Etag);
             Assert.Equal(expectedVersions[1].Etag, actual[1].Etag);
+        }
+
+        #endregion
+
+        #region UpdateQuotaTargetsAsync
+
+        [Fact]
+        public void Test_UpdateQuotaTargetsAsync_SurveyIdIsNull_Throws()
+        {
+            var target = new NfieldQuotaService();
+            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(target.UpdateQuotaTargetsAsync(null, quotaETag, quotaFrameTargets)));
+        }
+
+        [Fact]
+        public void Test_UpdateQuotaTargetsAsync_SurveyIdIsEmpty_Throws()
+        {
+            var target = new NfieldQuotaService();
+            Assert.Throws<ArgumentException>(() => UnwrapAggregateException(target.UpdateQuotaTargetsAsync(string.Empty, quotaETag, quotaFrameTargets)));
         }
 
         #endregion

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-2.14.{buildId}{suffix}
+2.15.{buildId}{suffix}


### PR DESCRIPTION
Since it is now possible to change quota during fieldwork, some new endpoints were added to query previous frames like is possible in the Nfield Manager.