### PR TITLE
[story] Create CAPI Basic Survey by API in Nfield Manager

### DIFF
--- a/Library/Infrastructure/NfieldSdkInitializer.cs
+++ b/Library/Infrastructure/NfieldSdkInitializer.cs
@@ -77,7 +77,8 @@ namespace Nfield.Infrastructure
             { typeof(INfieldLocalUserService), typeof(NfieldLocalUserService) },
             { typeof(INfieldCatiInterviewersService), typeof(NfieldCatiInterviewersService) },
             { typeof(INfieldSurveyVersionsService), typeof(NfieldSurveyVersionsService) },
-            { typeof(INfieldQuotaService), typeof(NfieldQuotaService) }
+            { typeof(INfieldQuotaService), typeof(NfieldQuotaService) },
+            { typeof(INfieldSurveySamplingMethodService), typeof(NfieldSurveySamplingMethodService) }
         };
 
         /// <summary>

--- a/Library/Models/SamplingMethodModel.cs
+++ b/Library/Models/SamplingMethodModel.cs
@@ -1,0 +1,26 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.Models
+{
+    public class SamplingMethodModel
+    {
+        /// <summary>
+        /// The sampling method type.
+        /// Supported values: FreeIntercept, JointTargets, IndividualTargets, SamplingPoints, Addresses, AddressesWithQuota
+        /// </summary>
+        public string SamplingMethod { get; set; }
+    }
+}

--- a/Library/Models/SamplingMethodType.cs
+++ b/Library/Models/SamplingMethodType.cs
@@ -1,0 +1,58 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.Models
+{
+    /// <summary>
+    /// The sampling method of a CAPI survey
+    /// </summary>
+    public enum SamplingMethodType
+    {
+        /// <summary>
+        /// Unknown (not set yet)
+        /// </summary>
+        Unknown,
+
+        /// <summary>
+        /// No quota target
+        /// </summary>
+        FreeIntercept,
+
+        /// <summary>
+        /// Joint target(s) for quota
+        /// </summary>
+        JointTargets,
+
+        /// <summary>
+        /// Individual target(s) for quota
+        /// </summary>
+        IndividualTargets,
+
+        /// <summary>
+        /// Survey type Advanced
+        /// </summary>
+        SamplingPoints,
+
+        /// <summary>
+        /// Survey type EuroBarometer
+        /// </summary>
+        Addresses,
+
+        /// <summary>
+        /// Survey type EuroBarometerAdvanced
+        /// </summary>
+        AddressesWithQuota
+    }
+}

--- a/Library/Services/INfieldSurveySamplingMethodService.cs
+++ b/Library/Services/INfieldSurveySamplingMethodService.cs
@@ -1,0 +1,40 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Nfield.Models;
+using System.Threading.Tasks;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// The survey sampling method service.
+    /// Allows to get and update the sampling method of a CAPI survey.
+    /// </summary>
+    public interface INfieldSurveySamplingMethodService
+    {
+        /// <summary>
+        /// Returns the CAPI survey's sampling method
+        /// </summary>
+        /// <param name="surveyId">The id of the survey to get the sampling method of</param>
+        Task<SamplingMethodType> GetAsync(string surveyId);
+
+        /// <summary>
+        /// Updates the CAPI survey's sampling method
+        /// </summary>
+        /// <param name="surveyId">The id of the survey to update the sampling method of</param>
+        /// <param name="samplingMethod">The sampling method to set the survey to</param>
+        Task UpdateAsync(string surveyId, SamplingMethodType samplingMethod);
+    }
+}

--- a/Library/Services/Implementation/NfieldSurveySamplingMethodService.cs
+++ b/Library/Services/Implementation/NfieldSurveySamplingMethodService.cs
@@ -1,0 +1,85 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using System;
+using System.Threading.Tasks;
+
+namespace Nfield.Services.Implementation
+{
+    /// <summary>
+    /// Implementation of <see cref="INfieldSurveySamplingMethodService"/>
+    /// </summary>
+    internal class NfieldSurveySamplingMethodService : INfieldSurveySamplingMethodService, INfieldConnectionClientObject
+    {
+        private INfieldHttpClient Client => ConnectionClient.Client;
+
+        #region Implementation of INfieldSurveySamplingMethodService
+
+        public async Task<SamplingMethodType> GetAsync(string surveyId)
+        {
+            CheckSurveyId(surveyId);
+
+            var result = await Client.GetAsync(SurveySamplingMethodUri(surveyId)).ConfigureAwait(false);
+
+            var content = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            var samplingMethodModel = JsonConvert.DeserializeObject<SamplingMethodModel>(content);
+
+            return (SamplingMethodType)Enum.Parse(typeof(SamplingMethodType), samplingMethodModel.SamplingMethod);
+        }
+
+        public async Task UpdateAsync(string surveyId, SamplingMethodType samplingMethod)
+        {
+            CheckSurveyId(surveyId);
+
+            var samplingMethodModel = new SamplingMethodModel
+            {
+                SamplingMethod = samplingMethod.ToString()
+            };
+
+            await Client.PatchAsJsonAsync(SurveySamplingMethodUri(surveyId), samplingMethodModel).ConfigureAwait(false);
+        }
+
+        private Uri SurveySamplingMethodUri(string surveyId)
+        {
+            return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/SamplingMethod/");
+        }
+
+        private static void CheckSurveyId(string surveyId)
+        {
+            if (surveyId == null)
+                throw new ArgumentNullException(nameof(surveyId));
+
+            if (surveyId.Trim().Length.Equals(0))
+                throw new ArgumentException("surveyId cannot be empty");
+        }
+
+        #endregion
+
+        #region Implementation of INfieldConnectionClientObject
+
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        #endregion
+    }
+}

--- a/Tests/Services/NfieldSurveySamplingMethodTests.cs
+++ b/Tests/Services/NfieldSurveySamplingMethodTests.cs
@@ -1,0 +1,118 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using Nfield.Services.Implementation;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Tests for <see cref="NfieldSurveySampleService"/>
+    /// </summary>
+    public class NfieldSurveySamplingMethodTests : NfieldServiceTestsBase
+    {
+        private const string SurveyId = "MySurvey";
+
+        private readonly NfieldSurveySamplingMethodService _target;
+        readonly Mock<INfieldHttpClient> _mockedHttpClient;
+
+        public NfieldSurveySamplingMethodTests()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            _mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            _target = new NfieldSurveySamplingMethodService();
+            _target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+        }
+
+        private Uri ServiceRequestUri()
+        {
+            string relativeUri = $"Surveys/{SurveyId}/SamplingMethod/";
+
+            return new Uri(ServiceAddress, relativeUri);
+        }
+
+        #region GetAsync
+
+        [Fact]
+        public void TestGetAsync_SurveyIdIsNull_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(_target.GetAsync(null)));
+        }
+
+        [Fact]
+        public void TestGetAsync_SurveyIdIsEmpty_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => UnwrapAggregateException(_target.GetAsync("   ")));
+        }
+
+        [Fact]
+        public void TestGetAsync_SurveyIdIsValid_ReturnsSamplingMethod()
+        {
+            var expectedModel = new SamplingMethodModel
+            {
+                SamplingMethod = SamplingMethodType.FreeIntercept.ToString()
+            };
+
+            _mockedHttpClient
+                .Setup(client => client.GetAsync(ServiceRequestUri()))
+                .Returns(CreateTask(HttpStatusCode.OK, new StringContent(JsonConvert.SerializeObject(expectedModel))));
+
+            var actual = _target.GetAsync(SurveyId).Result;
+
+            Assert.Equal(expectedModel.SamplingMethod, actual.ToString());
+        }
+
+        #endregion
+
+        #region UpdateAsync
+
+        [Fact]
+        public void TestUpdateAsync_SurveyIdIsNull_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(_target.UpdateAsync(null, SamplingMethodType.FreeIntercept)));
+        }
+
+        [Fact]
+        public void TestUpdateAsync_SurveyIdIsEmpty_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => UnwrapAggregateException(_target.UpdateAsync("   ", SamplingMethodType.FreeIntercept)));
+        }
+
+        [Fact]
+        public void TestUpdateAsync_SurveyIdIsValid_RunsToCompletion()
+        {
+            var expectedTaskStatus = TaskStatus.RanToCompletion;
+
+            _mockedHttpClient
+                .Setup(client => client.PatchAsJsonAsync(ServiceRequestUri(), It.IsAny<SamplingMethodType>()))
+                .Returns(CreateTask(HttpStatusCode.OK));
+
+            var actual = _target.UpdateAsync(SurveyId, SamplingMethodType.FreeIntercept);
+
+            Assert.Equal(expectedTaskStatus, actual.Status);
+        }
+
+        #endregion
+    }
+}

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-2.17.{buildId}{suffix}
+2.18.{buildId}{suffix}


### PR DESCRIPTION
Support calling the  SamplingMethod endpoints in the SDK.

See also [nfield-source](https://github.com/NIPOSoftwareBV/nfield-source/pull/5924)

See also [glu-api](https://github.com/NIPOSoftwareBV/project-glu-api/pull/2853)

[AB#77421](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/77421)
