### PR TITLE
Swap CodeAnalysis.FxCopAnalyzers for CodeAnalysis.NetAnalyzers

### DIFF
--- a/CodeAnalysis/NipoSoftware.DefaultProjectRules.targets
+++ b/CodeAnalysis/NipoSoftware.DefaultProjectRules.targets
@@ -3,6 +3,7 @@
     <RelativePathToCodeAnalysis Condition="'$(RelativePathToCodeAnalysis)' == ''">..</RelativePathToCodeAnalysis>
   </PropertyGroup>
   <PropertyGroup>
+    <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <RunCodeAnalysis>false</RunCodeAnalysis><!-- disable legacy code analysis -->
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>$(RelativePathToCodeAnalysis)\CodeAnalysis\Standard Rules for NIPO Software.ruleset</CodeAnalysisRuleSet>

--- a/Library/Nfield.SDK.csproj
+++ b/Library/Nfield.SDK.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.3.1">
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Nfield.SDK.sln
+++ b/Nfield.SDK.sln
@@ -17,6 +17,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml
 		LICENSE.txt = LICENSE.txt
+		CodeAnalysis\NipoSoftware.DefaultProjectRules.targets = CodeAnalysis\NipoSoftware.DefaultProjectRules.targets
 		README.md = README.md
 		CodeAnalysis\Standard rules for NIPO Software.ruleset = CodeAnalysis\Standard rules for NIPO Software.ruleset
 		version.txt = version.txt


### PR DESCRIPTION
[AB#85340](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/85340)

The package [Microsoft.CodeAnalysis.FxCopAnalyzers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.FxCopAnalyzers) has been deprecated in favor of [Microsoft.CodeAnalysis.NetAnalyzers](https://www.nuget.org/packages/Microsoft.CodeAnalysis.NetAnalyzers/).

`Microsoft.CodeAnalysis.NetAnalyzers` is much [more conservative](https://docs.microsoft.com/en-us/dotnet/fundamentals/code-analysis/overview#enabled-rules) compared to `Microsoft.CodeAnalysis.FxCopAnalyzers`.

We therefor set the `AnalysisMode` to `AllEnabledByDefault`. (see [migration steps](https://docs.microsoft.com/en-us/visualstudio/code-quality/migrate-from-fxcop-analyzers-to-net-analyzers?view=vs-2019#migration-steps) for more information)

---

Related PRs:

- https://github.com/NIPOSoftwareBV/Nfield-Cati/pull/608
- https://github.com/NIPOSoftwareBV/nfield-source/pull/6231
- https://github.com/NIPOSoftwareBV/Nfield-Activities/pull/27
- https://github.com/NIPOSoftwareBV/project-glu-api/pull/3100
- https://github.com/NIPOSoftwareBV/nfield-permissions/pull/78
- https://github.com/NIPOSoftwareBV/nfield-tenant-signup/pull/141
- https://github.com/NIPOSoftwareBV/nfield-nativeengine/pull/111
- https://github.com/NIPOSoftwareBV/nfield-reporting-events/pull/113
- https://github.com/NIPOSoftwareBV/nfield-storage/pull/215
- https://github.com/NIPOSoftwareBV/nfield-odinparser/pull/62
- https://github.com/NIPOSoftwareBV/nfield-remote-mediator/pull/30
- https://github.com/NIPOSoftwareBV/nfield-interviewing-contracts/pull/30
- https://github.com/NIPOSoftwareBV/nfield-survey-fieldwork-package/pull/39
- https://github.com/NIPOSoftware/Nfield-SDK/pull/224
- https://github.com/NIPOSoftware/Nfield.Quota/pull/106