### PR TITLE
[AB#88530] Code analysis: disable "warnings as error" in debug builds

### DIFF
--- a/CodeAnalysis/NipoSoftware.DefaultProjectRules.targets
+++ b/CodeAnalysis/NipoSoftware.DefaultProjectRules.targets
@@ -9,5 +9,8 @@
     <CodeAnalysisRuleSet>$(RelativePathToCodeAnalysis)\CodeAnalysis\Standard Rules for NIPO Software.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisAdditionalOptions>/assemblyCompareMode:StrongNameIgnoringVersion</CodeAnalysisAdditionalOptions>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+  </PropertyGroup>
   <Target Name="Standard Rules"></Target>
 </Project>


### PR DESCRIPTION
'Warnings as Errors' is very annoying while working on code. For example, unused variables are not allowed, which is common while code is not yet finished.

With this PR warnings as errors is enabled for release builds but not debug builds in all repos.

Running tests were not required.