### PR TITLE
Nfield API - Add missing endpoints (spike and first controller implementation)

### DIFF
--- a/Library/Services/INfieldFieldworkOfficesService.cs
+++ b/Library/Services/INfieldFieldworkOfficesService.cs
@@ -22,8 +22,10 @@ using Nfield.Models;
 
 namespace Nfield.Services
 {
+
+
     /// <summary>
-    /// Represents a set of methods to read the fieldwork office data.
+    /// Represents a set of methods to read and manage fieldwork offices.
     /// </summary>
     public interface INfieldFieldworkOfficesService
     {
@@ -35,5 +37,35 @@ namespace Nfield.Services
         /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
         /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>   
         Task<IQueryable<FieldworkOffice>> QueryAsync();
+
+        /// <summary>
+        /// Adds a new fieldwork office.
+        /// </summary>
+        /// <param name="office">The fieldwork office to add.</param>
+        /// <exception cref="T:System.AggregateException"></exception>
+        /// The aggregate exception can contain:
+        /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
+        /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>
+        Task<FieldworkOffice> AddAsync(FieldworkOffice office);
+
+        /// <summary>
+        /// Removes a fieldwork office.
+        /// </summary>
+        /// <param name="office">The fieldwork office to remove.</param>
+        /// <exception cref="T:System.AggregateException"></exception>
+        /// The aggregate exception can contain:
+        /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
+        /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>       
+        Task RemoveAsync(FieldworkOffice office);
+
+        /// <summary>
+        /// Updates the details of a fieldwork office.
+        /// </summary>
+        /// <param name="interviewer">The fieldwork office to update.</param>
+        /// <exception cref="T:System.AggregateException"></exception> 
+        /// The aggregate exception can contain:
+        /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
+        /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>
+        Task<FieldworkOffice> UpdateAsync(FieldworkOffice office);
     }
 }

--- a/Library/Services/INfieldFieldworkOfficesService.cs
+++ b/Library/Services/INfieldFieldworkOfficesService.cs
@@ -13,12 +13,9 @@
 //    You should have received a copy of the GNU Lesser General Public License
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Nfield.Models;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace Nfield.Services
 {
@@ -34,8 +31,8 @@ namespace Nfield.Services
         /// <exception cref="T:System.AggregateException"></exception>
         /// </summary>
         /// The aggregate exception can contain:
-        /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
-        /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>   
+        /// <exception cref="Exceptions.NfieldErrorException"></exception>
+        /// <exception cref="Exceptions.NfieldHttpResponseException"></exception>   
         Task<IQueryable<FieldworkOffice>> QueryAsync();
 
         /// <summary>
@@ -44,8 +41,8 @@ namespace Nfield.Services
         /// <param name="office">The fieldwork office to add.</param>
         /// <exception cref="T:System.AggregateException"></exception>
         /// The aggregate exception can contain:
-        /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
-        /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>
+        /// <exception cref="Exceptions.NfieldErrorException"></exception>
+        /// <exception cref="Exceptions.NfieldHttpResponseException"></exception>
         Task<FieldworkOffice> AddAsync(FieldworkOffice office);
 
         /// <summary>
@@ -54,18 +51,18 @@ namespace Nfield.Services
         /// <param name="office">The fieldwork office to remove.</param>
         /// <exception cref="T:System.AggregateException"></exception>
         /// The aggregate exception can contain:
-        /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
-        /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>       
+        /// <exception cref="Exceptions.NfieldErrorException"></exception>
+        /// <exception cref="Exceptions.NfieldHttpResponseException"></exception>       
         Task RemoveAsync(FieldworkOffice office);
 
         /// <summary>
         /// Updates the details of a fieldwork office.
         /// </summary>
-        /// <param name="interviewer">The fieldwork office to update.</param>
+        /// <param name="office">The fieldwork office to update.</param>
         /// <exception cref="T:System.AggregateException"></exception> 
         /// The aggregate exception can contain:
-        /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
-        /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>
+        /// <exception cref="Exceptions.NfieldErrorException"></exception>
+        /// <exception cref="Exceptions.NfieldHttpResponseException"></exception>
         Task<FieldworkOffice> UpdateAsync(FieldworkOffice office);
     }
 }

--- a/Library/Services/Implementation/NfieldFieldworkOfficesService.cs
+++ b/Library/Services/Implementation/NfieldFieldworkOfficesService.cs
@@ -45,6 +45,71 @@ namespace Nfield.Services.Implementation
              .FlattenExceptions();
         }
 
+        /// <summary>
+        /// See <see cref="INfieldFieldworkOfficesService.AddAsync"/>
+        /// </summary>
+        public Task<FieldworkOffice> AddAsync(FieldworkOffice office)
+        {
+            if (office == null)
+            {
+                throw new ArgumentNullException(nameof(office));
+            }
+
+            if (!string.IsNullOrEmpty(office.OfficeId))
+            {
+                throw new ArgumentException(nameof(office.OfficeId));
+            }
+
+            return ConnectionClient.Client.PostAsJsonAsync(OfficesApi, office)
+                         .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(task => JsonConvert.DeserializeObject<FieldworkOffice>(task.Result))
+                         .FlattenExceptions();
+        }
+
+        /// <summary>
+        /// See <see cref="INfieldFieldworkOfficesService.RemoveAsync"/>
+        /// </summary>
+        public Task RemoveAsync(FieldworkOffice office)
+        {
+            if (office == null)
+            {
+                throw new ArgumentNullException(nameof(office));
+            }
+
+            return
+                ConnectionClient.Client.DeleteAsync(new Uri(OfficesApi, office.OfficeId))
+                      .FlattenExceptions();
+        }
+
+        /// <summary>
+        /// See <see cref="INfieldFieldworkOfficesService.UpdateAsync"/>
+        /// </summary>
+        public Task<FieldworkOffice> UpdateAsync(FieldworkOffice office)
+        {
+            if (office == null)
+            {
+                throw new ArgumentNullException(nameof(office));
+            }
+
+            if (string.IsNullOrEmpty(office.OfficeId))
+            {
+                throw new ArgumentException(nameof(office.OfficeId));
+            }
+
+            var updatedOffice = new UpdateOffice
+            {
+                OfficeName = office.OfficeName,
+                Description = office.Description
+            };
+
+            return ConnectionClient.Client.PatchAsJsonAsync(new Uri(OfficesApi, office.OfficeId), updatedOffice)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask => JsonConvert.DeserializeObject<FieldworkOffice>(stringTask.Result))
+                         .FlattenExceptions();
+        }
+
         #endregion
 
         #region Implementation of INfieldConnectionClientObject
@@ -61,6 +126,12 @@ namespace Nfield.Services.Implementation
         private Uri OfficesApi
         {
             get { return new Uri(ConnectionClient.NfieldServerUri, "offices/"); }
+        }
+
+        internal class UpdateOffice
+        {
+            public string OfficeName { get; set; }
+            public string Description { get; set; }
         }
 
     }

--- a/Postman/FieldworkOffices.postman_collection.json
+++ b/Postman/FieldworkOffices.postman_collection.json
@@ -1,0 +1,276 @@
+{
+	"info": {
+		"_postman_id": "4151c996-1b1f-436f-af24-bd472a8ced37",
+		"name": "FieldworkOffices",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get Offices",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Status code name has string\", function () {",
+							"    pm.response.to.have.status(\"OK\");",
+							"});",
+							"",
+							"const hasOfficeName = (office) => {",
+							"    return office.OfficeName !== undefined;",
+							"}",
+							"",
+							"pm.test(\"All offices should have an OfficeName\", function () {",
+							"    const offices = pm.response.json();",
+							"    pm.expect(offices.every(hasOfficeName)).to.be.true;",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/octet-stream"
+					},
+					{
+						"key": "Authorization",
+						"value": "Basic {{AuthenticationToken}}"
+					}
+				],
+				"url": {
+					"raw": "{{origin}}/v1/Offices",
+					"host": [
+						"{{origin}}"
+					],
+					"path": [
+						"v1",
+						"Offices"
+					]
+				},
+				"description": "This method retrieves a list of surveys. This list can be filtered and sorted using standard OData syntax."
+			},
+			"response": []
+		},
+		{
+			"name": "Get Office by Id",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Status code name has string\", function () {",
+							"    pm.response.to.have.status(\"OK\");",
+							"});",
+							"",
+							"pm.test(\"All offices should have an OfficeName\", function () {",
+							"    const office = pm.response.json();",
+							"    pm.expect(office.OfficeName !== undefined).to.be.true;",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "Authorization",
+						"value": "Basic {{AuthenticationToken}}"
+					}
+				],
+				"url": {
+					"raw": "{{origin}}/v1/Offices/{{OfficeId}}",
+					"host": [
+						"{{origin}}"
+					],
+					"path": [
+						"v1",
+						"Offices",
+						"{{OfficeId}}"
+					]
+				},
+				"description": "This method retrieve details of a specific survey."
+			},
+			"response": []
+		},
+		{
+			"name": "Create Office",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Response contains OfficeId\", function () {",
+							"    const office = pm.response.json();",
+							"    pm.expect(office.OfficeId.length).to.eql(36);",
+							"    pm.environment.set(\"OfficeId\", office.OfficeId);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "Authorization",
+						"value": "Basic {{AuthenticationToken}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"OfficeName\": \"office\",\r\n  \"Description\": \"description\"\r\n }"
+				},
+				"url": {
+					"raw": "{{origin}}/v1/Offices",
+					"host": [
+						"{{origin}}"
+					],
+					"path": [
+						"v1",
+						"Offices"
+					]
+				},
+				"description": "This method creates a new survey."
+			},
+			"response": []
+		},
+		{
+			"name": "Patch Office",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Status code name has string\", function () {",
+							"    pm.response.to.have.status(\"OK\");",
+							"});",
+							"",
+							"pm.test(\"Updated description\", function () {",
+							"    const office = pm.response.json();",
+							"    pm.expect(office.Description).to.eql(\"description updated\");",
+							"});",
+							"",
+							"pm.test(\"Updated officeName\", function () {",
+							"    const office = pm.response.json();",
+							"    pm.expect(office.OfficeName).to.eql(\"office updated\");",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "PATCH",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "Authorization",
+						"value": "Basic {{AuthenticationToken}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"OfficeName\": \"office updated\",\r\n  \"Description\": \"description updated\"\r\n }"
+				},
+				"url": {
+					"raw": "{{origin}}/v1/Offices/{{OfficeId}}",
+					"host": [
+						"{{origin}}"
+					],
+					"path": [
+						"v1",
+						"Offices",
+						"{{OfficeId}}"
+					]
+				},
+				"description": "Update a survey with the specified fields."
+			},
+			"response": []
+		},
+		{
+			"name": "Remove Office",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"//pm.environment.unset(\"OfficeId\");",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "Authorization",
+						"value": "Basic {{AuthenticationToken}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{origin}}/v1/Offices/{{OfficeId}}",
+					"host": [
+						"{{origin}}"
+					],
+					"path": [
+						"v1",
+						"Offices",
+						"{{OfficeId}}"
+					]
+				},
+				"description": "This method deletes a specified survey."
+			},
+			"response": []
+		}
+	]
+}

--- a/Tests/Services/NfieldFieldworkOfficesServiceTests.cs
+++ b/Tests/Services/NfieldFieldworkOfficesServiceTests.cs
@@ -24,6 +24,7 @@ using System.Threading.Tasks;
 using System.Net;
 using Newtonsoft.Json;
 using System.Linq;
+using static Nfield.Services.Implementation.NfieldFieldworkOfficesService;
 
 namespace Nfield.Services
 {
@@ -68,6 +69,126 @@ namespace Nfield.Services
             Assert.Equal(expectedFieldworkOffices[0].OfficeId, actualFieldworkOffices.ToArray()[0].OfficeId);
             Assert.Equal(expectedFieldworkOffices[1].OfficeId, actualFieldworkOffices.ToArray()[1].OfficeId);
             Assert.Equal(2, actualFieldworkOffices.Count());
+        }
+
+        #endregion
+
+        #region AddAsync
+
+        [Fact]
+        public void TestAddAsync_OfficeIsNull_ThrowsArgumentNullException()
+        {
+            var target = new NfieldFieldworkOfficesService();
+            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(target.AddAsync(null)));
+        }
+
+        [Fact]
+        public void TestAddAsync_OfficeIdHasValue_ThrowsArgumentException()
+        {
+            var target = new NfieldFieldworkOfficesService();
+            Assert.Throws<ArgumentException>(() => UnwrapAggregateException(target.AddAsync(
+                new FieldworkOffice
+                {
+                    OfficeId = "Some value"
+                })));
+        }
+
+        [Fact]
+        public void TestAddAsync_ServerAcceptsOffice_ReturnsOffice()
+        {
+            var office = new FieldworkOffice { OfficeName = "Office X", Description = "New office"};
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+            var content = new StringContent(JsonConvert.SerializeObject(office));
+            mockedHttpClient
+                .Setup(client => client.PostAsJsonAsync(new Uri(ServiceAddress, "offices/"), office))
+                .Returns(CreateTask(HttpStatusCode.OK, content));
+
+            var target = new NfieldFieldworkOfficesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = target.AddAsync(office).Result;
+
+            Assert.Equal(office.OfficeName, actual.OfficeName);
+            Assert.Equal(office.Description, actual.Description);
+        }
+
+        #endregion
+
+        #region RemoveAsync
+
+        [Fact]
+        public void TestRemoveAsync_OfficeIsNull_ThrowsArgumentNullException()
+        {
+            var target = new NfieldFieldworkOfficesService();
+            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(target.RemoveAsync(null)));
+        }
+
+        [Fact]
+        public void TestRemoveAsync_ServerRemovedFieldworkOffice_DoesNotThrow()
+        {
+            const string removeOfficeId = "Office X";
+            var office = new FieldworkOffice { OfficeId = removeOfficeId };
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+            mockedHttpClient
+                .Setup(client => client.DeleteAsync(new Uri(ServiceAddress, "offices/" + removeOfficeId)))
+                .Returns(CreateTask(HttpStatusCode.OK));
+
+            var target = new NfieldFieldworkOfficesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            // assert: no throw
+            target.RemoveAsync(office).Wait();
+        }
+
+        #endregion
+
+        #region UpdateAsync
+
+        [Fact]
+        public void TestUpdateAsync_FieldworkOfficeArgumentIsNull_ThrowsArgumentNullException()
+        {
+            var target = new NfieldFieldworkOfficesService();
+            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(target.UpdateAsync(null)));
+        }
+
+        [Fact]
+        public void TestUpdateAsync_OfficeIsNull_ThrowsArgumentNullException()
+        {
+            var target = new NfieldFieldworkOfficesService();
+            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(target.UpdateAsync(null)));
+        }
+
+        [Fact]
+        public void TestUpdateAsync_OfficeIdIsNull_ThrowsArgumentException()
+        {
+            var target = new NfieldFieldworkOfficesService();
+            Assert.Throws<ArgumentException>(() => UnwrapAggregateException(target.UpdateAsync(
+                new FieldworkOffice())));
+        }
+
+        [Fact]
+        public void TestUpdateAsync_ServerAcceptsOffice_ReturnsOffice()
+        {
+            var office = new FieldworkOffice { OfficeId = "ID", OfficeName = "Office X Name", Description = "Updated Description" };
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+            var content = new StringContent(JsonConvert.SerializeObject(office));
+
+            mockedHttpClient
+                .Setup(client => client.PatchAsJsonAsync(new Uri(ServiceAddress, "offices/" + office.OfficeId),
+                    It.Is<UpdateOffice>(u => u.OfficeName == office.OfficeName && u.Description == office.Description)))
+                .Returns(CreateTask(HttpStatusCode.OK, content));
+
+            var target = new NfieldFieldworkOfficesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = target.UpdateAsync(office).Result;
+
+            Assert.Equal(office.OfficeId, actual.OfficeId);
+            Assert.Equal(office.OfficeName, actual.OfficeName);
+            Assert.Equal(office.Description, actual.Description);
         }
 
         #endregion

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-2.24.{buildId}{suffix}
+2.25.{buildId}{suffix}


### PR DESCRIPTION
Story: [AB#95126](https://dev.azure.com/niposoftware/Nfield/_workitems/edit/95126/)

Related PRs:

[Spike document](https://github.com/NIPOSoftwareBV/Nfield-Documentation/pull/2752) (read first)

[Offices endpoint in Public API](https://github.com/NIPOSoftwareBV/nfield-source/pull/6788)