### PR TITLE
AB#95899 - API: Add domain password settings endpoints

### DIFF
--- a/Library/Infrastructure/NfieldSdkInitializer.cs
+++ b/Library/Infrastructure/NfieldSdkInitializer.cs
@@ -45,6 +45,7 @@ namespace Nfield.Infrastructure
             { typeof(INfieldLanguagesService), typeof(NfieldLanguagesService) },
             { typeof(INfieldTranslationsService), typeof(NfieldTranslationsService) },
             { typeof(INfieldDomainEmailSettingsService), typeof(NfieldDomainEmailSettingsService) },
+            { typeof(INfieldDomainPasswordSettingsService), typeof(NfieldDomainPasswordSettingsService) },
             { typeof(INfieldDomainSearchFieldsSettingService), typeof(NfieldDomainSearchFieldsSettingService) },
             { typeof(INfieldSurveyEmailSettingsService), typeof(NfieldSurveyEmailSettingsService) },
             { typeof(INfieldSurveyInvitationImagesService), typeof(NfieldSurveyInvitationImagesService) },

--- a/Library/Models/DomainPasswordSettings.cs
+++ b/Library/Models/DomainPasswordSettings.cs
@@ -1,0 +1,44 @@
+﻿namespace Nfield.Models
+{
+    /// <summary>
+    /// The password settings of the domain
+    /// </summary>
+    public class DomainPasswordSettings
+    {
+        /// <summary>
+        /// Name of the password setting that determines warn when password expires in x days for a domain
+        /// The valid values for the AgeWarnThreshold from 0 to 10
+        /// </summary>
+        public int? AgeWarnThreshold { get; set; }
+
+        /// <summary>
+        /// Name of the password setting that indicates if two-factor authentication is enforced for a domain
+        /// </summary>
+        public bool? EnforceTwoFactorAuthentication { get; set; }
+
+        /// <summary>
+        /// Name of the password setting that determines maximum password age in days for a domain
+        /// The valid values for the maximum password age: 0, 30, 60, 90, 365
+        /// </summary>
+        public int? MaxPasswordAge { get; set; }
+
+        /// <summary>
+        /// Name of the password setting that determines minimum char sets in password for a domain
+        /// The valid values for the minimum char sets in password from 0 to 4
+        /// </summary>
+        public int? MinCharsetsInPassword { get; set; }
+
+        /// <summary>
+        /// Name of the password setting that determines minimum password length for a domain
+        /// The valid values for the minimum password length: 0, 6, 8, 12
+        /// </summary>
+        public int? MinPasswordLength { get; set; }
+
+        /// <summary>
+        /// Name of the password setting that number of passwords kept in password history (new password must be different then these) for a domain
+        /// The valid values for the password history Length from 0 to 10
+        /// </summary>
+        public int? PasswordHistoryLength { get; set; }
+
+    }
+}

--- a/Library/Services/INfieldDomainPasswordSettingsService.cs
+++ b/Library/Services/INfieldDomainPasswordSettingsService.cs
@@ -1,0 +1,36 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Threading.Tasks;
+using Nfield.Models;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Service for getting and changing the password settings at the domain level
+    /// </summary>
+    public interface INfieldDomainPasswordSettingsService
+    {
+        /// <summary>
+        /// Gets the password settings at the domain level
+        /// </summary>
+        Task<DomainPasswordSettings> GetAsync();
+
+        /// <summary>
+        /// Changes the password settings at the domain level 
+        /// </summary>
+        Task<DomainPasswordSettings> UpdateAsync(DomainPasswordSettings settings);
+    }
+}

--- a/Library/Services/Implementation/NfieldDomainPasswordSettingsService.cs
+++ b/Library/Services/Implementation/NfieldDomainPasswordSettingsService.cs
@@ -1,0 +1,62 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Nfield.Extensions;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using Nfield.Utilities;
+
+namespace Nfield.Services.Implementation
+{
+    internal class NfieldDomainPasswordSettingsService : INfieldDomainPasswordSettingsService, INfieldConnectionClientObject
+    {
+        public Task<DomainPasswordSettings> GetAsync()
+        {
+            var uri = DomainPasswordSettingsUrl();
+
+            return Client.GetAsync(uri)
+                         .ContinueWith(task => JsonConvert.DeserializeObject<DomainPasswordSettings>(
+                            task.Result.Content.ReadAsStringAsync().Result))
+                         .FlattenExceptions();
+        }
+
+        public Task<DomainPasswordSettings> UpdateAsync(DomainPasswordSettings settings)
+        {
+            Ensure.ArgumentNotNull(settings, nameof(settings));
+
+            var uri = DomainPasswordSettingsUrl();
+
+            return Client.PatchAsJsonAsync(uri, settings)
+                        .ContinueWith(task => JsonConvert.DeserializeObject<DomainPasswordSettings>(
+                            task.Result.Content.ReadAsStringAsync().Result))
+                        .FlattenExceptions();
+        }
+
+        private INfieldHttpClient Client => ConnectionClient.Client;
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        private Uri DomainPasswordSettingsUrl()
+        {
+            return new Uri(ConnectionClient.NfieldServerUri, "PasswordSettings/");
+        }
+    }
+}

--- a/Postman/DomainSettings.postman_collection.json
+++ b/Postman/DomainSettings.postman_collection.json
@@ -18,17 +18,7 @@
 							"",
 							"pm.test(\"Status code name has string\", function () {",
 							"    pm.response.to.have.status(\"OK\");",
-							"});",
-							"",
-							"const hasOfficeName = (office) => {",
-							"    return office.OfficeName !== undefined;",
-							"}",
-							"",
-							"pm.test(\"All offices should have an OfficeName\", function () {",
-							"    const offices = pm.response.json();",
-							"    pm.expect(offices.every(hasOfficeName)).to.be.true;",
-							"});",
-							""
+							"});"
 						],
 						"type": "text/javascript"
 					}
@@ -47,13 +37,13 @@
 					}
 				],
 				"url": {
-					"raw": "{{origin}}/v1/Offices",
+					"raw": "{{origin}}/v1/PasswordSettings",
 					"host": [
 						"{{origin}}"
 					],
 					"path": [
 						"v1",
-						"Offices"
+						"PasswordSettings"
 					]
 				},
 				"description": "This method retrieves a list of surveys. This list can be filtered and sorted using standard OData syntax."
@@ -94,7 +84,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n  \"AgeWarnThreshold\": \"0\",\r\n  \"EnforceTwoFactorAuthentication\": \"false\",\r\n  \"MaxPasswordAge\": \"0\",\r\n  \"MinCharsetsInPassword\": \"0\",\r\n  \"MinPasswordLength\": \"0\",\r\n  \"PasswordHistoryLength\": \"0\"\r\n }"
+					"raw": "{\r\n    \"AgeWarnThreshold\": 0,\r\n    \"EnforceTwoFactorAuthentication\": false,\r\n    \"MaxPasswordAge\": 0,\r\n    \"MinCharsetsInPassword\": 2,\r\n    \"MinPasswordLength\": 6,\r\n    \"PasswordHistoryLength\": 0\r\n}"
 				},
 				"url": {
 					"raw": "{{origin}}/v1/PasswordSettings",

--- a/Postman/DomainSettings.postman_collection.json
+++ b/Postman/DomainSettings.postman_collection.json
@@ -1,0 +1,114 @@
+{
+	"info": {
+		"_postman_id": "69c66594-05a1-4882-a99b-1731302a339f",
+		"name": "DomainSettings",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get Password Settings",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Status code name has string\", function () {",
+							"    pm.response.to.have.status(\"OK\");",
+							"});",
+							"",
+							"const hasOfficeName = (office) => {",
+							"    return office.OfficeName !== undefined;",
+							"}",
+							"",
+							"pm.test(\"All offices should have an OfficeName\", function () {",
+							"    const offices = pm.response.json();",
+							"    pm.expect(offices.every(hasOfficeName)).to.be.true;",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/octet-stream"
+					},
+					{
+						"key": "Authorization",
+						"value": "Basic {{AuthenticationToken}}"
+					}
+				],
+				"url": {
+					"raw": "{{origin}}/v1/Offices",
+					"host": [
+						"{{origin}}"
+					],
+					"path": [
+						"v1",
+						"Offices"
+					]
+				},
+				"description": "This method retrieves a list of surveys. This list can be filtered and sorted using standard OData syntax."
+			},
+			"response": []
+		},
+		{
+			"name": "Patch Password Settings",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Status code name has string\", function () {",
+							"    pm.response.to.have.status(\"OK\");",
+							"});",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "PATCH",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "Authorization",
+						"value": "Basic {{AuthenticationToken}}"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"AgeWarnThreshold\": \"0\",\r\n  \"EnforceTwoFactorAuthentication\": \"false\",\r\n  \"MaxPasswordAge\": \"0\",\r\n  \"MinCharsetsInPassword\": \"0\",\r\n  \"MinPasswordLength\": \"0\",\r\n  \"PasswordHistoryLength\": \"0\"\r\n }"
+				},
+				"url": {
+					"raw": "{{origin}}/v1/PasswordSettings",
+					"host": [
+						"{{origin}}"
+					],
+					"path": [
+						"v1",
+						"PasswordSettings"
+					]
+				},
+				"description": "Update a survey with the specified fields."
+			},
+			"response": []
+		}
+	]
+}

--- a/Tests/Services/NfieldDomainPasswordSettingsServiceTests.cs
+++ b/Tests/Services/NfieldDomainPasswordSettingsServiceTests.cs
@@ -1,0 +1,101 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using Nfield.Models;
+using Nfield.Services.Implementation;
+using Xunit;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Tests for <see cref="NfieldDomainPasswordSettingsService"/>
+    /// </summary>
+    public class NfieldDomainPasswordSettingsServiceTests : NfieldServiceTestsBase
+    {
+        #region GetAsync
+
+        [Fact]
+        public void TestGetAsync_ReturnsData()
+        {
+            var expected = new DomainPasswordSettings
+            {
+                AgeWarnThreshold = 0,
+                MaxPasswordAge = 30,
+                MinCharsetsInPassword = 2,
+                MinPasswordLength = 8,
+                PasswordHistoryLength = 0,
+                EnforceTwoFactorAuthentication = false
+            };
+
+            var target = new NfieldDomainPasswordSettingsService();
+            var mockClient = InitMockClientGet(PasswordSettingsUrl(), expected);
+            target.InitializeNfieldConnection(mockClient);
+
+            var actual = target.GetAsync().Result;
+            AssertOnPasswordSettings(expected, actual);
+        }
+
+        #endregion
+
+        #region Patch
+
+        [Fact]
+        public void TestUpdateAsync_SettingsNull_Throws()
+        {
+            var target = new NfieldDomainPasswordSettingsService();
+            Assert.Throws<ArgumentNullException>(() =>
+                UnwrapAggregateException(target.UpdateAsync(null)));
+        }
+
+        [Fact]
+        public void TestUpdateAsync_ReturnsData()
+        {
+            var expected = new DomainPasswordSettings
+            {
+                AgeWarnThreshold = 2,
+                MaxPasswordAge = 365,
+                MinCharsetsInPassword = 4,
+                MinPasswordLength = 8,
+                PasswordHistoryLength = 10,
+                EnforceTwoFactorAuthentication = true
+            };
+
+            var target = new NfieldDomainPasswordSettingsService();
+            var mockClient = InitMockClientPatch(PasswordSettingsUrl(), expected, expected);
+            target.InitializeNfieldConnection(mockClient);
+
+            var actual = target.UpdateAsync(expected).Result;
+            AssertOnPasswordSettings(expected, actual);
+        }
+
+        #endregion
+
+        private Uri PasswordSettingsUrl()
+        {
+            return new Uri(ServiceAddress, "PasswordSettings/");
+        }
+        
+        private static void AssertOnPasswordSettings(DomainPasswordSettings expected, DomainPasswordSettings actual)
+        {
+            Assert.Equal(expected.AgeWarnThreshold, actual.AgeWarnThreshold);
+            Assert.Equal(expected.EnforceTwoFactorAuthentication, actual.EnforceTwoFactorAuthentication);
+            Assert.Equal(expected.MaxPasswordAge, actual.MaxPasswordAge);
+            Assert.Equal(expected.MinCharsetsInPassword, actual.MinCharsetsInPassword);
+            Assert.Equal(expected.MinPasswordLength, actual.MinPasswordLength);
+            Assert.Equal(expected.PasswordHistoryLength, actual.PasswordHistoryLength);
+        }
+    }
+}

--- a/Tests/Services/NfieldServiceTestsBase.cs
+++ b/Tests/Services/NfieldServiceTestsBase.cs
@@ -105,5 +105,17 @@ namespace Nfield.Services
             return mockedNfieldConnection.Object;
         }
 
+        internal INfieldConnectionClient InitMockClientPatch<T1, T2>(Uri url, T1 requestContent, T2 responseObjectContent)
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+            var responseContent = new ObjectContent<T2>(responseObjectContent, new JsonMediaTypeFormatter());
+            mockedHttpClient
+                .Setup(client => client.PatchAsJsonAsync(url, requestContent))
+                .Returns(CreateTask(HttpStatusCode.OK, responseContent));
+
+            return mockedNfieldConnection.Object;
+        }
+
     }
 }

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-2.27.{buildId}{suffix}
+2.28.{buildId}{suffix}


### PR DESCRIPTION
[AB#95899](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/95899)
Add domain password settings endpoints to the public Api

PRs:
- https://github.com/NIPOSoftwareBV/nfield-source/pull/6859
- https://github.com/NIPOSoftware/Nfield-SDK/pull/248
