### PR TITLE
Create the structure of the new service

### DIFF
--- a/Library/Infrastructure/NfieldSdkInitializer.cs
+++ b/Library/Infrastructure/NfieldSdkInitializer.cs
@@ -52,7 +52,7 @@ namespace Nfield.Infrastructure
             { typeof(INfieldSurveyInvitationImagesService), typeof(NfieldSurveyInvitationImagesService) },
             { typeof(INfieldSurveyInvitationTemplatesService), typeof(NfieldSurveyInvitationTemplatesService) },
             { typeof(INfieldSurveySettingsService), typeof(NfieldSurveySettingsService) },
-            { typeof(INfieldSurveyOtherSettingsService), typeof(NfieldSurveyOtherSettingsService) },
+            { typeof(INfieldSurveyInterviewSettingsService), typeof(NfieldSurveyInterviewSettingsService) },
             { typeof(INfieldSurveyResponseCodesService), typeof(NfieldSurveyResponseCodesService) },
             { typeof(INfieldSurveyRelocationsService), typeof(NfieldSurveyRelocationsService) },
             { typeof(INfieldSurveyPublicIdsService), typeof(NfieldSurveyPublicIdsService) },

--- a/Library/Models/SurveyInterviewSettings.cs
+++ b/Library/Models/SurveyInterviewSettings.cs
@@ -15,45 +15,12 @@
 
 namespace Nfield.Models
 {
-    public class SurveyOtherSettingsRequest
+    public class SurveyInterviewSettings
     {
-        public string Owner { get; set; }
-
         public bool? BackButtonAvailable { get; set; }
 
         public bool? PauseButtonAvailable { get; set; }
 
         public bool? ClearButtonAvailable { get; set; }
-
-        public bool? AllowOnlyKnownRespondents { get; set; }
-
-    }
-
-    public class SurveyOtherSettingsResponse
-    {
-        public string SurveyId { get; set; }
-
-        public User Owner { get; set; }
-
-        public string EncryptionKey { get; set; }
-
-        public bool BackButtonAvailable { get; set; }
-
-        public bool PauseButtonAvailable { get; set; }
-
-        public bool ClearButtonAvailable { get; set; }
-
-        public bool AllowOnlyKnownRespondents { get; set; }
-
-    }
-
-    public class User
-    {
-        /// <summary>
-        /// Unique Id of user
-        /// </summary>
-        public string Id { get; set; }
-
-        public string UserName { get; set; }
     }
 }

--- a/Library/Services/INfieldSurveyInterviewSettingsService.cs
+++ b/Library/Services/INfieldSurveyInterviewSettingsService.cs
@@ -13,19 +13,24 @@
 //    You should have received a copy of the GNU Lesser General Public License
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
-using System;
+using System.Threading.Tasks;
 using Nfield.Models;
-using Nfield.Services.Implementation;
-using Xunit;
 
 namespace Nfield.Services
 {
     /// <summary>
-    /// Tests for <see cref="NfieldSurveyOtherSettingsService"/>
+    /// Service for getting and changing the interview settings for a survey
     /// </summary>
-    public class NfieldSurveyOtherSettingsServiceTests : NfieldServiceTestsBase
+    public interface INfieldSurveyInterviewSettingsService
     {
-        private const string SurveyId = "TestSurveyId";
+        /// <summary>
+        /// Gets the interview settings for a survey
+        /// </summary>
+        Task<SurveyInterviewSettings> GetAsync(string surveyId);
 
+        /// <summary>
+        /// Changes the interview settings for a survey
+        /// </summary>
+        Task<SurveyInterviewSettings> UpdateAsync(string surveyId, SurveyInterviewSettings settings);
     }
 }

--- a/Library/Services/Implementation/NfieldSurveyInterviewSettingsService.cs
+++ b/Library/Services/Implementation/NfieldSurveyInterviewSettingsService.cs
@@ -23,21 +23,21 @@ using Nfield.Utilities;
 
 namespace Nfield.Services.Implementation
 {
-    internal class NfieldSurveyOtherSettingsService : INfieldSurveyOtherSettingsService, INfieldConnectionClientObject
+    internal class NfieldSurveyInterviewSettingsService : INfieldSurveyInterviewSettingsService, INfieldConnectionClientObject
     {
-        public Task<SurveyOtherSettingsResponse> GetAsync(string surveyId)
+        public Task<SurveyInterviewSettings> GetAsync(string surveyId)
         {
             Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
 
             var uri = SurveyOtherSettingsUrl(surveyId);
 
             return Client.GetAsync(uri)
-                         .ContinueWith(task => JsonConvert.DeserializeObject<SurveyOtherSettingsResponse>(
+                         .ContinueWith(task => JsonConvert.DeserializeObject<SurveyInterviewSettings>(
                             task.Result.Content.ReadAsStringAsync().Result))
                          .FlattenExceptions();
         }
 
-        public Task<SurveyOtherSettingsResponse> UpdateAsync(string surveyId, SurveyOtherSettingsRequest settings)
+        public Task<SurveyInterviewSettings> UpdateAsync(string surveyId, SurveyInterviewSettings settings)
         {
             Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
             Ensure.ArgumentNotNull(settings, nameof(settings));
@@ -45,7 +45,7 @@ namespace Nfield.Services.Implementation
             var uri = SurveyOtherSettingsUrl(surveyId);
 
             return Client.PatchAsJsonAsync(uri, settings)
-                        .ContinueWith(task => JsonConvert.DeserializeObject<SurveyOtherSettingsResponse>(
+                        .ContinueWith(task => JsonConvert.DeserializeObject<SurveyInterviewSettings>(
                             task.Result.Content.ReadAsStringAsync().Result))
                         .FlattenExceptions();
         }
@@ -59,7 +59,7 @@ namespace Nfield.Services.Implementation
 
         private Uri SurveyOtherSettingsUrl(string surveyId)
         {
-            return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/OtherSettings");
+            return new Uri(ConnectionClient.NfieldServerUri, $"Surveys/{surveyId}/InterviewSettings");
         }
     }
 }

--- a/Postman/SurveyInterviewSettings.postman_collection.json
+++ b/Postman/SurveyInterviewSettings.postman_collection.json
@@ -1,12 +1,12 @@
 {
 	"info": {
 		"_postman_id": "88ee5923-bdeb-4840-99cf-c407bd9786d8",
-		"name": "SurveyOtherSettings",
+		"name": "SurveyInterviewSettings",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
-			"name": "Get Survey Other Settings",
+			"name": "Get SurveyInterviewSettings",
 			"event": [
 				{
 					"listen": "test",
@@ -34,12 +34,13 @@
 						"value": "application/octet-stream"
 					},
 					{
-						"key": "X-Nfield-Domain",
-						"value": "{{Domain}}"
+						"key": "Authorization",
+						"value": "Basic {{AuthenticationToken}}",
+						"type": "text"
 					}
 				],
 				"url": {
-					"raw": "{{origin}}/v1/Surveys/{{SurveyId}}/OtherSettings",
+					"raw": "{{origin}}/v1/Surveys/{{SurveyId}}/InterviewSettings",
 					"host": [
 						"{{origin}}"
 					],
@@ -47,7 +48,7 @@
 						"v1",
 						"Surveys",
 						"{{SurveyId}}",
-						"OtherSettings"
+						"InterviewSettings"
 					]
 				},
 				"description": "This method returns fieldwork status."
@@ -55,7 +56,7 @@
 			"response": []
 		},
 		{
-			"name": "Update Survey Other Settings",
+			"name": "Update SurveyInterviewSettings",
 			"event": [
 				{
 					"listen": "test",
@@ -90,7 +91,7 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\r\n    \"Owner\": \"owner\",\r\n    \"BackButtonAvailable\": true,\r\n    \"PauseButtonAvailable\": true,\r\n    \"ClearButtonAvailable\": true,\r\n    \"AllowOnlyKnownRespondents\": true\r\n}",
+					"raw": "{\r\n    \"BackButtonAvailable\": true,\r\n    \"PauseButtonAvailable\": true,\r\n    \"ClearButtonAvailable\": true\r\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -98,7 +99,7 @@
 					}
 				},
 				"url": {
-					"raw": "{{origin}}/v1/Surveys/{{SurveyId}}/OtherSettings",
+					"raw": "{{origin}}/v1/Surveys/{{SurveyId}}/InterviewSettings",
 					"host": [
 						"{{origin}}"
 					],
@@ -106,7 +107,7 @@
 						"v1",
 						"Surveys",
 						"{{SurveyId}}",
-						"OtherSettings"
+						"InterviewSettings"
 					]
 				}
 			},

--- a/Tests/Services/NfieldSurveyInterviewSettingsServiceTests.cs
+++ b/Tests/Services/NfieldSurveyInterviewSettingsServiceTests.cs
@@ -13,24 +13,19 @@
 //    You should have received a copy of the GNU Lesser General Public License
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
-using System.Threading.Tasks;
+using System;
 using Nfield.Models;
+using Nfield.Services.Implementation;
+using Xunit;
 
 namespace Nfield.Services
 {
     /// <summary>
-    /// Service for getting and changing the other settings for a survey (only at survey level)
+    /// Tests for <see cref="NfieldSurveyInterviewSettingsService"/>
     /// </summary>
-    public interface INfieldSurveyOtherSettingsService
+    public class NfieldSurveyInterviewSettingsServiceTests : NfieldServiceTestsBase
     {
-        /// <summary>
-        /// Gets the other settings for a survey
-        /// </summary>
-        Task<SurveyOtherSettingsResponse> GetAsync(string surveyId);
+        private const string SurveyId = "TestSurveyId";
 
-        /// <summary>
-        /// Changes the other settings for a survey (validation will be enforced on email addresses)
-        /// </summary>
-        Task<SurveyOtherSettingsResponse> UpdateAsync(string surveyId, SurveyOtherSettingsRequest settings);
     }
 }


### PR DESCRIPTION
[AB#98209](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/98209)

Still nothing working.
The idea is to start mapping everything from Glu-Api to see the issues that may popup

Notes:
- The 3 buttons are independent booleans (so we can do a direct mapping without any problem)
- Owner is a string in the request and a Use class in the response
- The Get response has an additional EncryptionKey field

Related PRs:
- https://github.com/NIPOSoftwareBV/nfield-source/pull/6918
- https://github.com/NIPOSoftware/Nfield-SDK/pull/264