### PR TITLE
API: Survey: New: Get (ResponseCodes) Counts ab#99039

### DIFF
--- a/Library/Models/SurveyFieldworkCounts.cs
+++ b/Library/Models/SurveyFieldworkCounts.cs
@@ -25,11 +25,7 @@ namespace Nfield.Models
         /// <summary>
         /// Survey Identifier
         /// </summary>
-        public string SurveyId { get; set; }
-        /// <summary>
-        /// Survey target
-        /// </summary>
-        public int? Target { get; set; }
+        public string SurveyId { get; set; }    
         /// <summary>
         /// Number of successful interviews
         /// </summary>
@@ -69,11 +65,7 @@ namespace Nfield.Models
         /// <summary>
         /// Number of active interviews
         /// </summary>
-        public int ActiveInterviews { get; set; }
-        /// <summary>
-        /// True if the survey has quota
-        /// </summary>
-        public bool HasQuota { get; set; }
+        public int ActiveInterviews { get; set; }       
         /// <summary>
         /// Overview of screen out interviews. Returns counts for each response code.
         /// </summary>

--- a/Library/Models/SurveyFieldworkCounts.cs
+++ b/Library/Models/SurveyFieldworkCounts.cs
@@ -1,0 +1,90 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+
+namespace Nfield.Models
+{
+    /// <summary>
+    /// Holds the survey fieldwork counts.
+    /// </summary>
+    public class SurveyFieldworkCounts
+    {
+        /// <summary>
+        /// Survey Identifier
+        /// </summary>
+        public string SurveyId { get; set; }
+        /// <summary>
+        /// Survey target
+        /// </summary>
+        public int? Target { get; set; }
+        /// <summary>
+        /// Number of successful interviews
+        /// </summary>
+        public int Successful { get; set; }
+        /// <summary>
+        /// Number of successful interviews in last 24 hours
+        /// </summary>
+        public int SuccessfulLast24Hours { get; set; }
+        /// <summary>
+        /// Number of screened out  interviews
+        /// </summary>
+        public int ScreenedOut { get; set; }
+        /// <summary>
+        /// Number of dropped out interviews
+        /// </summary>
+        public int DroppedOut { get; set; }
+        /// <summary>
+        /// Number of rejected interviews
+        /// </summary>
+        public int Rejected { get; set; }
+        /// <summary>
+        /// Number of successful interviews deleted
+        /// </summary>
+        public int SuccessfulDeleted { get; set; }
+        /// <summary>
+        /// Number of screened out interviews deleted
+        /// </summary>
+        public int ScreenedOutDeleted { get; set; }
+        /// <summary>
+        /// Number of dropped out interviews deleted
+        /// </summary>
+        public int DroppedOutDeleted { get; set; }
+        /// <summary>
+        /// Number of reject interviews deleted
+        /// </summary>
+        public int RejectedDeleted { get; set; }
+        /// <summary>
+        /// Number of active interviews
+        /// </summary>
+        public int ActiveInterviews { get; set; }
+        /// <summary>
+        /// True if the survey has quota
+        /// </summary>
+        public bool HasQuota { get; set; }
+        /// <summary>
+        /// Overview of screen out interviews. Returns counts for each response code.
+        /// </summary>
+        public IEnumerable<ResponseCodeCount> ScreenedOutOverview { get; set; }
+        /// <summary>
+        /// Class for the screen out interviews overview
+        /// </summary>
+        public class ResponseCodeCount
+        {
+            public int ResponseCode { get; set; }
+            public int Count { get; set; }
+        }
+    }
+}

--- a/Library/Services/INfieldSurveyFieldworkService.cs
+++ b/Library/Services/INfieldSurveyFieldworkService.cs
@@ -48,5 +48,14 @@ namespace Nfield.Services
         /// </summary>
         /// <param name="surveyId">The id of the survey to Start</param>
         Task FinishFieldworkAsync(string surveyId);
+
+        /// <summary>
+        /// Gets survey fieldwork counts
+        /// <exception cref="T:System.AggregateException"></exception>
+        /// </summary>
+        /// The aggregate exception can contain:
+        /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
+        /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception> 
+        Task<SurveyFieldworkCounts> GetCountsAsync(string surveyId);
     }
 }

--- a/Library/Services/Implementation/NfieldSurveyFieldworkService.cs
+++ b/Library/Services/Implementation/NfieldSurveyFieldworkService.cs
@@ -16,6 +16,7 @@
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 using Nfield.Extensions;
 using Nfield.Infrastructure;
 using Nfield.Models;
@@ -78,6 +79,22 @@ namespace Nfield.Services.Implementation
             var uri = new Uri(SurveysApi, $"{surveyId}/{SurveyFieldworkControllerName}/Finish");
 
             return Client.PutAsync(uri, new StringContent(string.Empty)).FlattenExceptions();
+        }
+
+        /// <summary>
+        /// See <see cref="INfieldFieldworkCountsService.GetAsync(string)"/>
+        /// </summary>
+        public Task<SurveyFieldworkCounts> GetCountsAsync(string surveyId)
+        {
+            var uri = new Uri(SurveysApi, $"{surveyId}/{SurveyFieldworkControllerName}/Counts");
+
+            return ConnectionClient.Client.GetAsync(uri)
+             .ContinueWith(
+                 responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+             .ContinueWith(
+                 stringTask =>
+                 JsonConvert.DeserializeObject<SurveyFieldworkCounts>(stringTask.Result))
+             .FlattenExceptions();
         }
 
         #endregion

--- a/Library/Services/Implementation/NfieldSurveyFieldworkService.cs
+++ b/Library/Services/Implementation/NfieldSurveyFieldworkService.cs
@@ -20,6 +20,7 @@ using Newtonsoft.Json;
 using Nfield.Extensions;
 using Nfield.Infrastructure;
 using Nfield.Models;
+using Nfield.Quota.Helpers;
 
 namespace Nfield.Services.Implementation
 {
@@ -86,6 +87,8 @@ namespace Nfield.Services.Implementation
         /// </summary>
         public Task<SurveyFieldworkCounts> GetCountsAsync(string surveyId)
         {
+            Ensure.ArgumentNotNullOrEmptyString(surveyId, nameof(surveyId));
+
             var uri = new Uri(SurveysApi, $"{surveyId}/{SurveyFieldworkControllerName}/Counts");
 
             return ConnectionClient.Client.GetAsync(uri)

--- a/Library/Services/Implementation/NfieldSurveyFieldworkService.cs
+++ b/Library/Services/Implementation/NfieldSurveyFieldworkService.cs
@@ -83,7 +83,7 @@ namespace Nfield.Services.Implementation
         }
 
         /// <summary>
-        /// See <see cref="INfieldFieldworkCountsService.GetAsync(string)"/>
+        /// See <see cref="INfieldSurveyFieldworkService.GetCountsAsync(string)"/>
         /// </summary>
         public Task<SurveyFieldworkCounts> GetCountsAsync(string surveyId)
         {

--- a/Postman/SurveyFieldwork.postman_collection.json
+++ b/Postman/SurveyFieldwork.postman_collection.json
@@ -59,6 +59,58 @@
 			"response": []
 		},
 		{
+			"name": "Get SurveyFieldwork Counts",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "978e4eb1-cfaa-4d22-9fe6-8e4d95c89030",
+						"type": "text/javascript",
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Status code name has string\", function () {",
+							"    pm.response.to.have.status(\"OK\");",
+							"});",
+							"",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/octet-stream"
+					},
+					{
+						"key": "Authorization",
+						"value": "Basic {{AuthenticationToken}}"
+					}
+				],
+				"body": {},
+				"url": {
+					"raw": "{{origin}}/v1/Surveys/{{SurveyId}}/Fieldwork/Counts",
+					"host": [
+						"{{origin}}"
+					],
+					"path": [
+						"v1",
+						"Surveys",
+						"{{SurveyId}}",
+						"Fieldwork",
+						"Counts"
+					]
+				},
+				"description": "This method returns fieldwork counts."
+			},
+			"response": []
+		},
+		{
 			"name": "Start SurveyFieldwork",
 			"event": [
 				{

--- a/Tests/Services/NfieldSurveyFieldworkServiceTests.cs
+++ b/Tests/Services/NfieldSurveyFieldworkServiceTests.cs
@@ -238,7 +238,7 @@ namespace Nfield.Services
         [Fact]
         public void TestGetCountsAsync_WhenSurveyIdIsNull_Throws()
         {
-            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(_target.FinishFieldworkAsync(null)));
+            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(_target.GetCountsAsync(null)));
         }
 
         [Fact]

--- a/Tests/Services/NfieldSurveyFieldworkServiceTests.cs
+++ b/Tests/Services/NfieldSurveyFieldworkServiceTests.cs
@@ -188,7 +188,7 @@ namespace Nfield.Services
         }
         #endregion
 
-        #region FinishFieldworkAsync
+        #region GetCountsAsync
 
         [Fact]
         public async void TestGetCountsAsync_ReturnRightValues()

--- a/Tests/Services/NfieldSurveyFieldworkServiceTests.cs
+++ b/Tests/Services/NfieldSurveyFieldworkServiceTests.cs
@@ -14,10 +14,12 @@
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Formatting;
 using Moq;
+using Newtonsoft.Json;
 using Nfield.Infrastructure;
 using Nfield.Models;
 using Nfield.Services.Implementation;
@@ -184,7 +186,71 @@ namespace Nfield.Services
             _mockedHttpClient
                 .Verify(client => client.PutAsync(new Uri(ServiceAddress, "Surveys/" + surveyId + "/Fieldwork/Finish"), It.IsAny<HttpContent>()), Times.Once());
         }
+        #endregion
 
+        #region FinishFieldworkAsync
+
+        [Fact]
+        public async void TestGetCountsAsync_ReturnRightValues()
+        {
+            // Setup
+            string surveyId = Guid.NewGuid().ToString();
+            var random = new Random();
+            var expectedResult = new SurveyFieldworkCounts
+            {
+                ActiveInterviews = random.Next(20),
+                DroppedOut = random.Next(20),
+                DroppedOutDeleted = random.Next(20),
+                HasQuota = random.Next(1) == 1,
+                SurveyId = surveyId,
+                Rejected = random.Next(20),
+                RejectedDeleted = random.Next(20),
+                ScreenedOut = random.Next(20),
+                ScreenedOutDeleted = random.Next(20),
+                ScreenedOutOverview = new[] { new SurveyFieldworkCounts.ResponseCodeCount { ResponseCode = 201 + random.Next(20), Count = random.Next(20) } },
+                Successful = random.Next(20),
+                SuccessfulDeleted = random.Next(20),
+                SuccessfulLast24Hours = random.Next(20),
+                Target = 50 + random.Next(20)
+            };
+            _mockedHttpClient.Setup(c => c.GetAsync(It.Is<Uri>(u=>u.ToString().EndsWith("Surveys/" + surveyId + "/Fieldwork/Counts"))))
+                .Returns(CreateTask(HttpStatusCode.OK, new StringContent(JsonConvert.SerializeObject(expectedResult)))).Verifiable();
+
+            // Act
+            var result = await  _target.GetCountsAsync(surveyId);
+
+            // Asserts
+            _mockedHttpClient.Verify();
+            Assert.Equal(expectedResult.ActiveInterviews, result.ActiveInterviews);
+            Assert.Equal(expectedResult.DroppedOut, result.DroppedOut);
+            Assert.Equal(expectedResult.DroppedOutDeleted, result.DroppedOutDeleted);
+            Assert.Equal(expectedResult.HasQuota, result.HasQuota);
+            Assert.Equal(expectedResult.SurveyId, result.SurveyId);
+            Assert.Equal(expectedResult.Rejected, result.Rejected);
+            Assert.Equal(expectedResult.RejectedDeleted, result.RejectedDeleted);
+            Assert.Equal(expectedResult.ScreenedOut, result.ScreenedOut);
+            Assert.Equal(expectedResult.ScreenedOutDeleted, result.ScreenedOutDeleted);
+            Assert.Equal(expectedResult.ScreenedOutOverview.Count(), result.ScreenedOutOverview.Count());
+            Assert.Equal(expectedResult.ScreenedOutOverview.First().Count, result.ScreenedOutOverview.First().Count);
+            Assert.Equal(expectedResult.ScreenedOutOverview.First().ResponseCode, result.ScreenedOutOverview.First().ResponseCode);
+            Assert.Equal(expectedResult.Successful, result.Successful);
+            Assert.Equal(expectedResult.SuccessfulDeleted, result.SuccessfulDeleted);
+            Assert.Equal(expectedResult.SuccessfulLast24Hours, result.SuccessfulLast24Hours);
+            Assert.Equal(expectedResult.Target, result.Target);
+        }
+
+        [Fact]
+        public void TestGetCountsAsync_WhenSurveyIdIsNull_Throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(_target.FinishFieldworkAsync(null)));
+        }
+
+        [Fact]
+        public void TestGetCountsAsync_WhenSurveyIdIsEmptyString_Throws()
+        {
+            Assert.Throws<ArgumentException>(() => UnwrapAggregateException(_target.FinishFieldworkAsync(string.Empty)));
+        }
+
+        #endregion
     }
-    #endregion
 }

--- a/Tests/Services/NfieldSurveyFieldworkServiceTests.cs
+++ b/Tests/Services/NfieldSurveyFieldworkServiceTests.cs
@@ -244,7 +244,7 @@ namespace Nfield.Services
         [Fact]
         public void TestGetCountsAsync_WhenSurveyIdIsEmptyString_Throws()
         {
-            Assert.Throws<ArgumentException>(() => UnwrapAggregateException(_target.FinishFieldworkAsync(string.Empty)));
+            Assert.Throws<ArgumentException>(() => UnwrapAggregateException(_target.GetCountsAsync(string.Empty)));
         }
 
         #endregion

--- a/Tests/Services/NfieldSurveyFieldworkServiceTests.cs
+++ b/Tests/Services/NfieldSurveyFieldworkServiceTests.cs
@@ -201,7 +201,6 @@ namespace Nfield.Services
                 ActiveInterviews = random.Next(20),
                 DroppedOut = random.Next(20),
                 DroppedOutDeleted = random.Next(20),
-                HasQuota = random.Next(1) == 1,
                 SurveyId = surveyId,
                 Rejected = random.Next(20),
                 RejectedDeleted = random.Next(20),
@@ -210,8 +209,7 @@ namespace Nfield.Services
                 ScreenedOutOverview = new[] { new SurveyFieldworkCounts.ResponseCodeCount { ResponseCode = 201 + random.Next(20), Count = random.Next(20) } },
                 Successful = random.Next(20),
                 SuccessfulDeleted = random.Next(20),
-                SuccessfulLast24Hours = random.Next(20),
-                Target = 50 + random.Next(20)
+                SuccessfulLast24Hours = random.Next(20)
             };
             _mockedHttpClient.Setup(c => c.GetAsync(It.Is<Uri>(u=>u.ToString().EndsWith("Surveys/" + surveyId + "/Fieldwork/Counts"))))
                 .Returns(CreateTask(HttpStatusCode.OK, new StringContent(JsonConvert.SerializeObject(expectedResult)))).Verifiable();
@@ -224,7 +222,6 @@ namespace Nfield.Services
             Assert.Equal(expectedResult.ActiveInterviews, result.ActiveInterviews);
             Assert.Equal(expectedResult.DroppedOut, result.DroppedOut);
             Assert.Equal(expectedResult.DroppedOutDeleted, result.DroppedOutDeleted);
-            Assert.Equal(expectedResult.HasQuota, result.HasQuota);
             Assert.Equal(expectedResult.SurveyId, result.SurveyId);
             Assert.Equal(expectedResult.Rejected, result.Rejected);
             Assert.Equal(expectedResult.RejectedDeleted, result.RejectedDeleted);
@@ -236,7 +233,6 @@ namespace Nfield.Services
             Assert.Equal(expectedResult.Successful, result.Successful);
             Assert.Equal(expectedResult.SuccessfulDeleted, result.SuccessfulDeleted);
             Assert.Equal(expectedResult.SuccessfulLast24Hours, result.SuccessfulLast24Hours);
-            Assert.Equal(expectedResult.Target, result.Target);
         }
 
         [Fact]

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-2.31.{buildId}{suffix}
+2.32.{buildId}{suffix}


### PR DESCRIPTION
API endpoint to get the survey fieldwork counts.
 [AB#99039](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/99039)

PRs:
https://github.com/NIPOSoftware/Nfield-SDK/pull/290
https://github.com/NIPOSoftwareBV/nfield-source/pull/7047

Tests:
- [x] Api integration tests