### PR TITLE
SDK: Add postman for survey sampling method

### DIFF
--- a/Postman/SurveySamplingMethod.postman_collection.json
+++ b/Postman/SurveySamplingMethod.postman_collection.json
@@ -1,0 +1,121 @@
+{
+	"info": {
+		"_postman_id": "80ebd36b-5c59-465a-9edc-67a2477bde7a",
+		"name": "SurveySamplingMethod",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Get SamplingMethod",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Status code name has string\", function () {",
+							"    pm.response.to.have.status(\"OK\");",
+							"});",
+							"",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "GET",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/octet-stream"
+					},
+					{
+						"key": "X-Nfield-Domain",
+						"value": "{{Domain}}"
+					},
+					{
+						"key": "Authorization",
+						"value": "Basic {{AuthenticationToken}}",
+						"type": "text"
+					}
+				],
+				"url": {
+					"raw": "{{origin}}/v1/Surveys/{{SurveyId}}/SamplingMethod",
+					"host": [
+						"{{origin}}"
+					],
+					"path": [
+						"v1",
+						"Surveys",
+						"{{SurveyId}}",
+						"SamplingMethod"
+					]
+				},
+				"description": "This method returns the sampling method of a capi survey"
+			},
+			"response": []
+		},
+		{
+			"name": "Update SamplingMethod",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"    pm.response.to.have.status(200);",
+							"});",
+							"",
+							"pm.test(\"Status code name has string\", function () {",
+							"    pm.response.to.have.status(\"OK\");",
+							"});",
+							"",
+							""
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"method": "PATCH",
+				"header": [
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "X-Nfield-Domain",
+						"value": "{{Domain}}"
+					},
+					{
+						"key": "Authorization",
+						"value": "Basic {{AuthenticationToken}}",
+						"type": "text"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"SamplingMethod\": \"FreeIntercept\"\r\n}"
+				},
+				"url": {
+					"raw": "{{origin}}/v1/Surveys/{{SurveyId}}/SamplingMethod",
+					"host": [
+						"{{origin}}"
+					],
+					"path": [
+						"v1",
+						"Surveys",
+						"{{SurveyId}}",
+						"SamplingMethod"
+					]
+				},
+				"description": "This method updates the sampling method of a capi survey. The methods have restrictions based on quota, sampling points, etc."
+			},
+			"response": []
+		}
+	]
+}


### PR DESCRIPTION
[AB#99117](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/99117)

Survey Sampling Method had already been implemented in the past in the public Api, but didn't have a postman file.

PRs:
- https://github.com/NIPOSoftwareBV/nfield-source/pull/7063
- https://github.com/NIPOSoftware/Nfield-SDK/pull/295

Tests: See https://github.com/NIPOSoftwareBV/nfield-source/pull/7063