### PR TITLE
Password back in the editable model, remove password specific methods, cleanup

### DIFF
--- a/Library/Models/CapiInterviewers/CapiInterviewer.cs
+++ b/Library/Models/CapiInterviewers/CapiInterviewer.cs
@@ -15,7 +15,7 @@
 
 namespace Nfield.Models
 {
-    public class CapiInterviewer : EditCapiInterviewer
+    public class CapiInterviewer
     {
         /// <summary>
         /// Unique Id of Interviewer
@@ -26,5 +26,32 @@ namespace Nfield.Models
         /// The interviewer's username
         /// </summary>
         public string UserName { get; set; }
+
+        /// <summary>
+        /// First name of the interviewer
+        /// </summary>
+        public string FirstName { get; set; }
+
+        /// <summary>
+        /// Last name of the interviewer
+        /// </summary>
+        public string LastName { get; set; }
+
+        /// <summary>
+        /// Email Address of the interviewer
+        /// </summary>
+        public string EmailAddress { get; set; }
+
+        /// <summary>
+        /// TelephoneNumber of the interviewer
+        /// </summary>
+        public string TelephoneNumber { get; set; }
+
+        /// <summary>
+        /// Property indicating weather the interviewer is a supervisor or not.  
+        /// Supervisors have special powers e.g. they can enter and modify the 
+        /// device ID in the CAPI client application in the Settings page.
+        /// </summary>
+        public bool IsSupervisor { get; set; }
     }
 }

--- a/Library/Models/CapiInterviewers/CreateCapiInterviewer.cs
+++ b/Library/Models/CapiInterviewers/CreateCapiInterviewer.cs
@@ -15,10 +15,10 @@
 
 namespace Nfield.Models
 {
-    public class EditCapiInterviewer: CapiInterviewer
+    public class CreateCapiInterviewer: CapiInterviewer
     {
         /// <summary>
-        /// Password of the interviewer (separate so it can only be set)
+        /// Password of the interviewer (separate so it can only be set at create time, but not when updating)
         /// </summary>
         public string Password { get;  set; }
     }

--- a/Library/Models/CapiInterviewers/EditCapiInterviewer.cs
+++ b/Library/Models/CapiInterviewers/EditCapiInterviewer.cs
@@ -15,33 +15,11 @@
 
 namespace Nfield.Models
 {
-    public class EditCapiInterviewer
+    public class EditCapiInterviewer: CapiInterviewer
     {
         /// <summary>
-        /// First name of the interviewer
+        /// Password of the interviewer (separate so it can only be set)
         /// </summary>
-        public string FirstName { get; set; }
-
-        /// <summary>
-        /// Last name of the interviewer
-        /// </summary>
-        public string LastName { get; set; }
-
-        /// <summary>
-        /// Email Address of the interviewer
-        /// </summary>
-        public string EmailAddress { get; set; }
-
-        /// <summary>
-        /// TelephoneNumber of the interviewer
-        /// </summary>
-        public string TelephoneNumber { get; set; }
-
-        /// <summary>
-        /// Property indicating weather the interviewer is a supervisor or not.  
-        /// Supervisors have special powers e.g. they can enter and modify the 
-        /// device ID in the CAPI client application in the Settings page.
-        /// </summary>
-        public bool IsSupervisor { get; set; }
+        public string Password { get;  set; }
     }
 }

--- a/Library/Services/INfieldCapiInterviewersService.cs
+++ b/Library/Services/INfieldCapiInterviewersService.cs
@@ -26,19 +26,19 @@ namespace Nfield.Services
     public interface INfieldCapiInterviewersService
     {
         /// <summary>
-        /// Adds a new interviewer.
+        /// Adds a new CAPI interviewer.
         /// </summary>
-        /// <param name="interviewer">The interviewer to add.</param>
+        /// <param name="interviewer">The CAPI interviewer to add.</param>
         /// <exception cref="T:System.AggregateException"></exception>
         /// The aggregate exception can contain:
         /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
         /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>
-        Task<CapiInterviewer> AddAsync(EditCapiInterviewer interviewer);
+        Task<CapiInterviewer> AddAsync(CreateCapiInterviewer interviewer);
 
         /// <summary>
-        /// Removes the interviewer.
+        /// Removes the CAPI interviewer.
         /// </summary>
-        /// <param name="interviewer">The interviewer to remove.</param>
+        /// <param name="interviewer">The CAPI interviewer to remove.</param>
         /// <exception cref="T:System.AggregateException"></exception>
         /// The aggregate exception can contain:
         /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
@@ -46,17 +46,17 @@ namespace Nfield.Services
         Task RemoveAsync(CapiInterviewer interviewer);
 
         /// <summary>
-        /// Updates interviewers data.
+        /// Updates a CAPI interviewer's data.
         /// </summary>
-        /// <param name="interviewer">The interviewer to update.</param>
+        /// <param name="interviewer">The CAPI interviewer to update.</param>
         /// <exception cref="T:System.AggregateException"></exception> 
         /// The aggregate exception can contain:
         /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
         /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>
-        Task<CapiInterviewer> UpdateAsync(EditCapiInterviewer interviewer);
+        Task<CapiInterviewer> UpdateAsync(CapiInterviewer interviewer);
 
         /// <summary>
-        /// Gets interviewer queryable object.
+        /// Gets CAPI interviewer queryable object.
         /// <exception cref="T:System.AggregateException"></exception>
         /// </summary>
         /// The aggregate exception can contain:
@@ -65,21 +65,33 @@ namespace Nfield.Services
         Task<IQueryable<CapiInterviewer>> QueryAsync();
 
         /// <summary>
-        /// Gets the interviewer by clientId
+        /// Gets the CAPI interviewer by clientId
         /// </summary>
         /// <param name="clientInterviewerId"></param>
         /// <returns></returns>
         Task<CapiInterviewer> InterviewerByClientIdAsync(string clientInterviewerId);
 
         /// <summary>
-        /// Returns a list of fieldwork offices ids that the interviewer belongs to
+        /// Change the password of a CAPI interviewer
+        /// </summary>
+        /// <param name="interviewer">CAPI interviewer whose password to change</param>
+        /// <param name="password">the new password</param>
+        /// <exception cref="T:System.AggregateException"></exception>
+        /// The aggregate exception can contain:
+        /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
+        /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>     
+        Task<CapiInterviewer> ChangePasswordAsync(CapiInterviewer interviewer, string password);
+
+
+        /// <summary>
+        /// Returns a list of fieldwork offices ids that the CAPI interviewer belongs to
         /// </summary>
         /// <param name="interviewerId"></param>
         /// <returns></returns>
         Task<IEnumerable<string>> QueryOfficesOfInterviewerAsync(string interviewerId);
 
         /// <summary>
-        /// Assigns an interviewer to a fieldwork office
+        /// Assigns an CAPI interviewer to a fieldwork office
         /// </summary>
         /// <param name="interviewerId"></param>
         /// <param name="officeId"></param>
@@ -87,7 +99,7 @@ namespace Nfield.Services
         Task AddInterviewerToFieldworkOfficesAsync(string interviewerId, string officeId);
 
         /// <summary>
-        /// Unassigns an interviewer from a fieldwork office
+        /// Unassigns a CAPI interviewer from a fieldwork office
         /// </summary>
         /// <param name="interviewerId"></param>
         /// <param name="fieldworkOfficeId"></param>
@@ -95,7 +107,7 @@ namespace Nfield.Services
         Task RemoveInterviewerFromFieldworkOfficesAsync(string interviewerId, string fieldworkOfficeId);
 
         /// <summary>
-        /// Asks for interviewers work logs and gets the URL to perform the download (UTC datetime)
+        /// Asks for CAPI interviewer's work logs and gets the URL to perform the download (UTC datetime)
         /// </summary>
         /// <param name="query">Query model with UTC datetime</param>
         /// <returns>URL to download the file</returns>

--- a/Library/Services/INfieldCapiInterviewersService.cs
+++ b/Library/Services/INfieldCapiInterviewersService.cs
@@ -33,7 +33,7 @@ namespace Nfield.Services
         /// The aggregate exception can contain:
         /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
         /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>
-        Task<CapiInterviewer> AddAsync(CapiInterviewer interviewer);
+        Task<CapiInterviewer> AddAsync(EditCapiInterviewer interviewer);
 
         /// <summary>
         /// Removes the interviewer.
@@ -53,7 +53,7 @@ namespace Nfield.Services
         /// The aggregate exception can contain:
         /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
         /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>
-        Task<CapiInterviewer> UpdateAsync(CapiInterviewer interviewer);
+        Task<CapiInterviewer> UpdateAsync(EditCapiInterviewer interviewer);
 
         /// <summary>
         /// Gets interviewer queryable object.
@@ -70,17 +70,6 @@ namespace Nfield.Services
         /// <param name="clientInterviewerId"></param>
         /// <returns></returns>
         Task<CapiInterviewer> InterviewerByClientIdAsync(string clientInterviewerId);
-
-        /// <summary>
-        /// Change the password of an interviewer
-        /// </summary>
-        /// <param name="interviewer">interviewer whose password to change</param>
-        /// <param name="password">the new password</param>
-        /// <exception cref="T:System.AggregateException"></exception>
-        /// The aggregate exception can contain:
-        /// <exception cref="Nfield.Exceptions.NfieldErrorException"></exception>
-        /// <exception cref="Nfield.Exceptions.NfieldHttpResponseException"></exception>     
-        Task<CapiInterviewer> ChangePasswordAsync(CapiInterviewer interviewer, string password);
 
         /// <summary>
         /// Returns a list of fieldwork offices ids that the interviewer belongs to

--- a/Library/Services/Implementation/NfieldCapiInterviewersService.cs
+++ b/Library/Services/Implementation/NfieldCapiInterviewersService.cs
@@ -37,7 +37,7 @@ namespace Nfield.Services.Implementation
         /// <summary>
         /// See <see cref="INfieldCapiInterviewersService.AddAsync"/>
         /// </summary>
-        public Task<CapiInterviewer> AddAsync(EditCapiInterviewer interviewer)
+        public Task<CapiInterviewer> AddAsync(CreateCapiInterviewer interviewer)
         {
             if (interviewer == null)
             {
@@ -68,7 +68,7 @@ namespace Nfield.Services.Implementation
         /// <summary>
         /// See <see cref="INfieldCapiInterviewersService.UpdateAsync"/>
         /// </summary>
-        public Task<CapiInterviewer> UpdateAsync(EditCapiInterviewer interviewer)
+        public Task<CapiInterviewer> UpdateAsync(CapiInterviewer interviewer)
         {
             if (interviewer == null)
             {
@@ -166,7 +166,26 @@ namespace Nfield.Services.Implementation
                           .FlattenExceptions().ConfigureAwait(true);
         }
 
+        /// <summary>
+        /// See <see cref="INfieldInterviewersService.ChangePasswordAsync"/>
+        /// </summary>
+        public Task<CapiInterviewer> ChangePasswordAsync(CapiInterviewer interviewer, string password)
+        {
+            if (interviewer == null)
+            {
+                throw new ArgumentNullException("interviewer");
+            }
+
+            return Client.PutAsJsonAsync(new Uri(CapiInterviewersApi, interviewer.InterviewerId), (object)new { Password = password })
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask => JsonConvert.DeserializeObject<CapiInterviewer>(stringTask.Result))
+                         .FlattenExceptions();
+        }
+
         #endregion
+
 
         #region Implementation of INfieldConnectionClientObject
 

--- a/Library/Services/Implementation/NfieldCapiInterviewersService.cs
+++ b/Library/Services/Implementation/NfieldCapiInterviewersService.cs
@@ -37,24 +37,14 @@ namespace Nfield.Services.Implementation
         /// <summary>
         /// See <see cref="INfieldCapiInterviewersService.AddAsync"/>
         /// </summary>
-        public Task<CapiInterviewer> AddAsync(CapiInterviewer interviewer)
+        public Task<CapiInterviewer> AddAsync(EditCapiInterviewer interviewer)
         {
             if (interviewer == null)
             {
                 throw new ArgumentNullException(nameof(interviewer));
             }
 
-            var newCapiInterviewer = new NewCapiInterviewer
-            {
-                UserName = interviewer.UserName,
-                EmailAddress = interviewer.EmailAddress,
-                FirstName = interviewer.FirstName,
-                LastName = interviewer.LastName,
-                TelephoneNumber = interviewer.TelephoneNumber,
-                IsSupervisor = interviewer.IsSupervisor
-            };
-
-            return Client.PostAsJsonAsync(CapiInterviewersApi, newCapiInterviewer)
+            return Client.PostAsJsonAsync(CapiInterviewersApi, interviewer)
                          .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
                          .ContinueWith(task => JsonConvert.DeserializeObject<CapiInterviewer>(task.Result))
                          .FlattenExceptions();
@@ -78,23 +68,14 @@ namespace Nfield.Services.Implementation
         /// <summary>
         /// See <see cref="INfieldCapiInterviewersService.UpdateAsync"/>
         /// </summary>
-        public Task<CapiInterviewer> UpdateAsync(CapiInterviewer interviewer)
+        public Task<CapiInterviewer> UpdateAsync(EditCapiInterviewer interviewer)
         {
             if (interviewer == null)
             {
                 throw new ArgumentNullException(nameof(interviewer));
             }
 
-            var updatedInterviewer = new EditCapiInterviewer
-            {
-                EmailAddress = interviewer.EmailAddress,
-                FirstName = interviewer.FirstName,
-                LastName = interviewer.LastName,
-                TelephoneNumber = interviewer.TelephoneNumber,
-                IsSupervisor = interviewer.IsSupervisor
-            };
-
-            return Client.PatchAsJsonAsync(new Uri(CapiInterviewersApi, interviewer.InterviewerId), updatedInterviewer)
+            return Client.PatchAsJsonAsync(new Uri(CapiInterviewersApi, interviewer.InterviewerId), interviewer)
                          .ContinueWith(
                              responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
                          .ContinueWith(
@@ -130,24 +111,6 @@ namespace Nfield.Services.Implementation
                          .ContinueWith(
                              stringTask =>
                              JsonConvert.DeserializeObject<CapiInterviewer>(stringTask.Result))
-                         .FlattenExceptions();
-        }
-
-        /// <summary>
-        /// See <see cref="INfieldCapiInterviewersService.ChangePasswordAsync"/>
-        /// </summary>
-        public Task<CapiInterviewer> ChangePasswordAsync(CapiInterviewer interviewer, string password)
-        {
-            if (interviewer == null)
-            {
-                throw new ArgumentNullException(nameof(interviewer));
-            }
-
-            return Client.PutAsJsonAsync(new Uri(CapiInterviewersApi, interviewer.InterviewerId), new ResetPasswordModel { Password = password })
-                         .ContinueWith(
-                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
-                         .ContinueWith(
-                             stringTask => JsonConvert.DeserializeObject<CapiInterviewer>(stringTask.Result))
                          .FlattenExceptions();
         }
 
@@ -238,18 +201,6 @@ namespace Nfield.Services.Implementation
             public string Password { get; set; }
         }
 
-        internal class NewCapiInterviewer : EditCapiInterviewer
-        {
-            /// <summary>
-            /// The interviewer's username
-            /// </summary>
-            public string UserName { get; set; }
-
-            /// <summary>
-            /// The initial password for the interviewer.
-            /// </summary>
-            public string Password { get; set; }
-        }
         #endregion
     }
 }

--- a/Tests/Services/NfieldCapiInterviewersServiceTests.cs
+++ b/Tests/Services/NfieldCapiInterviewersServiceTests.cs
@@ -41,7 +41,7 @@ namespace Nfield.Services
         private const string LogsLink1 = "logs-link-1";
 
         private readonly Uri _capiInterviewersApi;
-        private readonly CapiInterviewer _interviewer;
+        private readonly EditCapiInterviewer _editCapiInterviewer;
         private readonly CapiInterviewer _capiInterviewer;
         private readonly NfieldCapiInterviewersService _target;
         private readonly Mock<INfieldHttpClient> _mockedHttpClient;
@@ -56,10 +56,10 @@ namespace Nfield.Services
             _target.InitializeNfieldConnection(_mockedNfieldConnection.Object);
             _capiInterviewersApi = new Uri(ServiceAddress, CapiInterviewersEndpoint);
 
-            _interviewer = new CapiInterviewer { InterviewerId = InterviewerId, UserName = "User X" };
+            _editCapiInterviewer = new EditCapiInterviewer { InterviewerId = InterviewerId, UserName = "User X" };
             _capiInterviewer = new CapiInterviewer {
-                InterviewerId = _interviewer.InterviewerId,
-                UserName = _interviewer.UserName
+                InterviewerId = _editCapiInterviewer.InterviewerId,
+                UserName = _editCapiInterviewer.UserName
             };
         }
 
@@ -71,14 +71,14 @@ namespace Nfield.Services
             // Arrange
             _mockedHttpClient
                 .Setup(client => client.PostAsJsonAsync(_capiInterviewersApi,
-                            It.Is<NewCapiInterviewer>(nci => nci.UserName == _interviewer.UserName)))
+                            It.Is<EditCapiInterviewer>(nci => nci.UserName == _editCapiInterviewer.UserName)))
                 .Returns(CreateTask(HttpStatusCode.OK, SerializedCapiInterviewer()));
 
             // Act
-            var actual = await _target.AddAsync(_interviewer);
+            var actual = await _target.AddAsync(_editCapiInterviewer);
 
             // Assert
-            Assert.Equal(_interviewer.UserName, actual.UserName);
+            Assert.Equal(_editCapiInterviewer.UserName, actual.UserName);
             Assert.Equal(_capiInterviewer.InterviewerId, actual.InterviewerId);
         }
 
@@ -103,7 +103,7 @@ namespace Nfield.Services
                 .Returns(CreateTask(HttpStatusCode.OK));
 
             // Act & Assert
-            await _target.RemoveAsync(_interviewer);
+            await _target.RemoveAsync(_editCapiInterviewer);
 
             // Assert
             _mockedHttpClient.Verify(
@@ -129,15 +129,15 @@ namespace Nfield.Services
             // Arrange
             _mockedHttpClient
                 .Setup(client => client.PatchAsJsonAsync(new Uri(_capiInterviewersApi, InterviewerId),
-                                        It.Is<EditCapiInterviewer>(uci => uci.FirstName == _interviewer.FirstName)))
+                                        It.Is<EditCapiInterviewer>(uci => uci.FirstName == _editCapiInterviewer.FirstName)))
                 .Returns(CreateTask(HttpStatusCode.OK, SerializedCapiInterviewer()));
 
             // Act
-            var actual = await _target.UpdateAsync(_interviewer);
+            var actual = await _target.UpdateAsync(_editCapiInterviewer);
 
             // Assert
-            Assert.Equal(_interviewer.InterviewerId, actual.InterviewerId);
-            Assert.Equal(_interviewer.FirstName, actual.FirstName);
+            Assert.Equal(_editCapiInterviewer.InterviewerId, actual.InterviewerId);
+            Assert.Equal(_editCapiInterviewer.FirstName, actual.FirstName);
         }
 
         #endregion
@@ -168,37 +168,7 @@ namespace Nfield.Services
 
         #endregion
 
-        #region ChangePasswordAsync
-
-        [Fact]
-        public void TestChangePasswordAsync_InterviewerIsNull_ThrowsArgumentNullException()
-        {
-            // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(_target.ChangePasswordAsync(null, string.Empty)));
-        }
-
-        [Fact]
-        public async Task TestChangePasswordAsync_ServerChangesPassword_ReturnsInterviewerAsync()
-        {
-            // Arrange
-            var expectedUrl = new Uri(_capiInterviewersApi, InterviewerId);
-            _mockedHttpClient
-                .Setup(client => client.PutAsJsonAsync(expectedUrl, It.IsAny<object>()))
-                .Returns(CreateTask(HttpStatusCode.OK, SerializedCapiInterviewer()));
-
-            // Act
-            var actual = await _target.ChangePasswordAsync(_interviewer, Password);
-
-            // Assert
-            Assert.Equal(_interviewer.InterviewerId, actual.InterviewerId);
-            _mockedHttpClient.Verify(
-                h =>
-                    h.PutAsJsonAsync(expectedUrl, It.Is<ResetPasswordModel>(o => o.Password  == Password )),
-                Times.Once());
-        }
-
-        #endregion
-
+       
         #region QueryOfficesOfInterviewerAsync
 
         [Fact]

--- a/Tests/Services/NfieldCapiInterviewersServiceTests.cs
+++ b/Tests/Services/NfieldCapiInterviewersServiceTests.cs
@@ -24,7 +24,6 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
-using static Nfield.Services.Implementation.NfieldCapiInterviewersService;
 
 namespace Nfield.Services
 {
@@ -35,13 +34,12 @@ namespace Nfield.Services
     {
         private const string CapiInterviewersEndpoint = "CapiInterviewers/";
         private const string InterviewerId = "Interviewer X";
-        private const string Password = "password";
         private const string FieldworkOfficeId = "Barcelona";
         private const string ActivityId = "activity-id";
         private const string LogsLink1 = "logs-link-1";
 
         private readonly Uri _capiInterviewersApi;
-        private readonly EditCapiInterviewer _editCapiInterviewer;
+        private readonly CreateCapiInterviewer _createCapiInterviewer;
         private readonly CapiInterviewer _capiInterviewer;
         private readonly NfieldCapiInterviewersService _target;
         private readonly Mock<INfieldHttpClient> _mockedHttpClient;
@@ -56,10 +54,10 @@ namespace Nfield.Services
             _target.InitializeNfieldConnection(_mockedNfieldConnection.Object);
             _capiInterviewersApi = new Uri(ServiceAddress, CapiInterviewersEndpoint);
 
-            _editCapiInterviewer = new EditCapiInterviewer { InterviewerId = InterviewerId, UserName = "User X" };
+            _createCapiInterviewer = new CreateCapiInterviewer { InterviewerId = InterviewerId, UserName = "User X" };
             _capiInterviewer = new CapiInterviewer {
-                InterviewerId = _editCapiInterviewer.InterviewerId,
-                UserName = _editCapiInterviewer.UserName
+                InterviewerId = _createCapiInterviewer.InterviewerId,
+                UserName = _createCapiInterviewer.UserName
             };
         }
 
@@ -71,14 +69,14 @@ namespace Nfield.Services
             // Arrange
             _mockedHttpClient
                 .Setup(client => client.PostAsJsonAsync(_capiInterviewersApi,
-                            It.Is<EditCapiInterviewer>(nci => nci.UserName == _editCapiInterviewer.UserName)))
+                            It.Is<CreateCapiInterviewer>(nci => nci.UserName == _createCapiInterviewer.UserName)))
                 .Returns(CreateTask(HttpStatusCode.OK, SerializedCapiInterviewer()));
 
             // Act
-            var actual = await _target.AddAsync(_editCapiInterviewer);
+            var actual = await _target.AddAsync(_createCapiInterviewer);
 
             // Assert
-            Assert.Equal(_editCapiInterviewer.UserName, actual.UserName);
+            Assert.Equal(_createCapiInterviewer.UserName, actual.UserName);
             Assert.Equal(_capiInterviewer.InterviewerId, actual.InterviewerId);
         }
 
@@ -103,7 +101,7 @@ namespace Nfield.Services
                 .Returns(CreateTask(HttpStatusCode.OK));
 
             // Act & Assert
-            await _target.RemoveAsync(_editCapiInterviewer);
+            await _target.RemoveAsync(_capiInterviewer);
 
             // Assert
             _mockedHttpClient.Verify(
@@ -129,15 +127,15 @@ namespace Nfield.Services
             // Arrange
             _mockedHttpClient
                 .Setup(client => client.PatchAsJsonAsync(new Uri(_capiInterviewersApi, InterviewerId),
-                                        It.Is<EditCapiInterviewer>(uci => uci.FirstName == _editCapiInterviewer.FirstName)))
+                                        It.Is<CapiInterviewer>(uci => uci.FirstName == _capiInterviewer.FirstName)))
                 .Returns(CreateTask(HttpStatusCode.OK, SerializedCapiInterviewer()));
 
             // Act
-            var actual = await _target.UpdateAsync(_editCapiInterviewer);
+            var actual = await _target.UpdateAsync(_capiInterviewer);
 
             // Assert
-            Assert.Equal(_editCapiInterviewer.InterviewerId, actual.InterviewerId);
-            Assert.Equal(_editCapiInterviewer.FirstName, actual.FirstName);
+            Assert.Equal(_capiInterviewer.InterviewerId, actual.InterviewerId);
+            Assert.Equal(_capiInterviewer.FirstName, actual.FirstName);
         }
 
         #endregion
@@ -292,6 +290,37 @@ namespace Nfield.Services
         }
 
         #endregion
+
+        #region ChangePasswordAsync
+
+        [Fact]
+        public void TestChangePasswordAsync_InterviewerIsNull_ThrowsArgumentNullException()
+        {
+            var target = new NfieldCapiInterviewersService();
+            Assert.Throws<ArgumentNullException>(() => UnwrapAggregateException(target.ChangePasswordAsync(null, string.Empty)));
+        }
+
+        [Fact]
+        public void TestChangePasswordAsync_ServerChangesPassword_ReturnsInterviewer()
+        {
+            const string Password = "Password";
+            const string InterviewerId = "Interviewer X";
+            var interviewer = new CapiInterviewer { InterviewerId = InterviewerId };
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+            mockedHttpClient
+                .Setup(client => client.PutAsJsonAsync(new Uri(_capiInterviewersApi, InterviewerId), It.IsAny<object>()))
+                .Returns(CreateTask(HttpStatusCode.OK, new StringContent(JsonConvert.SerializeObject(interviewer))));
+
+            var target = new NfieldCapiInterviewersService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = target.ChangePasswordAsync(interviewer, Password).Result;
+
+            Assert.Equal(interviewer.InterviewerId, actual.InterviewerId);
+        }
+
+#endregion
 
         #region private methods
         private StringContent SerializedCapiInterviewer()


### PR DESCRIPTION
Fixes that you cannot set a password when creating / updating the interviewer. Removes separately updating the password (you can use Update for that). When retrieving an interviewer, the password is not provided (so you can only set it, not read it).

[#105899](https://dev.azure.com/niposoftware/Nfield/_sprints/taskboard/Team%20Yellow/Nfield/Release%202022/2022%20P1S4?workitem=105899)