### PR TITLE
Fix Interviewer assignment tests

### DIFF
--- a/Library/Models/InterviewerAssignmentModel.cs
+++ b/Library/Models/InterviewerAssignmentModel.cs
@@ -46,11 +46,11 @@ namespace Nfield.Models
         /// <summary>
         /// Assigned or not
         /// </summary>
-        public bool IsAssigned { get; set; }
+        public bool? IsAssigned { get; set; }
         /// <summary>
         /// Active or not
         /// </summary>
-        public bool IsActive { get; set; }
+        public bool? IsActive { get; set; }
         // Is group assignment
         public bool? IsGroupAssignment { get; set; }
         /// <summary>


### PR DESCRIPTION
Fix the WebDriver tests that after enabling the toggle, were failing because of the survey assignments:
- TestAssignAsync_WhenInterviewerAddedToSurvey_CheckItsAssigned("2EurobarometerSurvey", SurveyType.EuroBarometer, false)
- TestUnassignAsync_WhenInterviewerAssignedToSurvey_CheckItsUnassigned("4EurobarometerSurvey", SurveyType.EuroBarometer, false)
- TestUnassignAsync_WhenInterviewerNotAddedToSurvey_DoesntThrow("3EurobarometerSurvey", SurveyType.EuroBarometer, false)
- TestDistributeAsync_WhenInterviewerAddedToSurvey_DoesntThrows("EurobarometerSurvey", SurveyType.EuroBarometer, false)
- TestAssignAsync_WhenInterviewerNotAddedToSurvey_Throws("1EurobarometerSurvey", SurveyType.EuroBarometer, false)
- SyncStatusCapiAndManagerTests.TestUnassignedInterviewer_SyncStatusUnchanged()
- PdfInterviewerInstructionsTests

The problem was that we were assigning/unassigning the interviewer from the survey. But the survey has sampling points, you need to assign/unassign from the sampling point, not the survey. Before it was allowed (but we shouldn't do that, because it doesn't have the expected behavior). For the tests it was fine, because we were just checking the Assignment table, and not the SamplingPoint assignment table

After using the correct method, the `GetInterviewerAssignmentsAsync`. When the assignment doesn't exist, we get null in the Assigned and Active columns. That was always the case, but because in the tests we were not really removing the assignment, it was working. I've changed the SDK to also make those values nullable