### PR TITLE
Public Api: interview quality startdate obsolete

### DIFF
--- a/Library/Models/InterviewDetailsModel.cs
+++ b/Library/Models/InterviewDetailsModel.cs
@@ -34,6 +34,7 @@ namespace Nfield.Models
         /// <summary>
         /// Date and Time the interview was started
         /// </summary>
+        [Obsolete("not supported on new nfield surveys")]
         public DateTime StartDate { get; set; }
 
         /// <summary>


### PR DESCRIPTION
[AB#116000](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/116000)

- Add obsolete attribute to StartDate property

PRs:
- https://github.com/NIPOSoftwareBV/nfield-source/pull/7758
- https://github.com/NIPOSoftware/Nfield-SDK/pull/349