### PR TITLE
Purple/wait for activity

### DIFF
--- a/Library/Services/INfieldSurveySampleDataService.cs
+++ b/Library/Services/INfieldSurveySampleDataService.cs
@@ -27,5 +27,10 @@ namespace Nfield.Services
         /// Start a new download sample data task, gets the task
         /// </summary>
         Task<BackgroundTask> GetAsync(string surveyId, string fileName);
+
+        /// <summary>
+        /// Start a new download sample data activity, gets the activity
+        /// </summary>
+        Task<string> PrepareDownloadSampleDataAsync(string surveyId, string fileName);
     }
 }

--- a/Library/Services/INfieldSurveySampleDataService.cs
+++ b/Library/Services/INfieldSurveySampleDataService.cs
@@ -29,7 +29,7 @@ namespace Nfield.Services
         Task<BackgroundTask> GetAsync(string surveyId, string fileName);
 
         /// <summary>
-        /// Start a new download sample data activity, gets the activity
+        /// Start a new download sample data activity and return the download url
         /// </summary>
         Task<string> PrepareDownloadSampleDataAsync(string surveyId, string fileName);
     }


### PR DESCRIPTION
Wait for the activity to finish and return the download URL (same as we do for the survey data download and many other activities)