### PR TITLE
Add delivery api endpoints

### DIFF
--- a/Library/Infrastructure/NfieldSdkInitializer.cs
+++ b/Library/Infrastructure/NfieldSdkInitializer.cs
@@ -93,8 +93,14 @@ namespace Nfield.Infrastructure
             { typeof(INfieldBlacklistService), typeof(NfieldBlacklistService) },
             { typeof(INfieldRequestsService), typeof(NfieldRequestsService) },
             { typeof(INfieldSamplingPointsService), typeof(NfieldSamplingPointsService) },
-            { typeof(INFieldMeService), typeof(NFieldMeService) }
-
+            { typeof(INFieldMeService), typeof(NFieldMeService) },
+            { typeof(INfieldDeliveryRepositoriesService), typeof(NfieldDeliveryRepositoriesService) },
+            { typeof(INfieldDeliveryRepositoryFirewallRulesService), typeof(NfieldDeliveryRepositoryFirewallRulesService) },
+            { typeof(INfieldDeliveryRepositorySurveysService), typeof(NfieldDeliveryRepositorySurveysService) },
+            { typeof(INfieldDeliveryRepositoryUsersService), typeof(NfieldDeliveryRepositoryUsersService) },
+            { typeof(INfieldDeliverySettingsService), typeof(NfieldDeliverySettingsService) },
+            { typeof(INfieldDeliverySurveyPropertiesService), typeof(NfieldDeliverySurveyPropertiesService) },
+            { typeof(INfieldDeliverySurveysService), typeof(NfieldDeliverySurveysService) }
         };
 
         /// <summary>

--- a/Library/Models/Delivery/Amount.cs
+++ b/Library/Models/Delivery/Amount.cs
@@ -15,10 +15,19 @@
 
 namespace Nfield.SDK.Models.Delivery
 {
+    /// <summary>
+    /// Model used in Delivery API for the pricing of the repository plan
+    /// </summary>
     public class Amount
     {
+        /// <summary>
+        /// The currency of the price amount
+        /// </summary>
         public string Currency { get; set; }
 
+        /// <summary>
+        /// The value of the price amount
+        /// </summary>
         public decimal Value { get; set; }
     }
 }

--- a/Library/Models/Delivery/Amount.cs
+++ b/Library/Models/Delivery/Amount.cs
@@ -1,0 +1,24 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.SDK.Models.Delivery
+{
+    public class Amount
+    {
+        public string Currency { get; set; }
+
+        public decimal Value { get; set; }
+    }
+}

--- a/Library/Models/Delivery/CreateDomainSurveyPropertyModel.cs
+++ b/Library/Models/Delivery/CreateDomainSurveyPropertyModel.cs
@@ -1,0 +1,27 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.SDK.Models.Delivery
+{
+    /// <summary>
+    /// Model used in Delivery API when creating a new Domain Survey Property.
+    /// </summary>
+    public class CreateDomainSurveyPropertyModel
+    {
+        public string Key { get; set; }
+
+        public string Value { get; set; }
+    }
+}

--- a/Library/Models/Delivery/CreateDomainSurveyPropertyModel.cs
+++ b/Library/Models/Delivery/CreateDomainSurveyPropertyModel.cs
@@ -20,8 +20,14 @@ namespace Nfield.SDK.Models.Delivery
     /// </summary>
     public class CreateDomainSurveyPropertyModel
     {
+        /// <summary>
+        /// The key of the survey property
+        /// </summary>
         public string Key { get; set; }
 
+        /// <summary>
+        /// The value of the the survey property's key
+        /// </summary>
         public string Value { get; set; }
     }
 }

--- a/Library/Models/Delivery/CreateRepositoryModel.cs
+++ b/Library/Models/Delivery/CreateRepositoryModel.cs
@@ -1,0 +1,24 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.SDK.Models.Delivery
+{
+    public class CreateRepositoryModel
+    {
+        public string Name { get; set; }
+
+        public long PlanId { get; set; }
+    }
+}

--- a/Library/Models/Delivery/CreateRepositoryModel.cs
+++ b/Library/Models/Delivery/CreateRepositoryModel.cs
@@ -15,10 +15,19 @@
 
 namespace Nfield.SDK.Models.Delivery
 {
+    /// <summary>
+    /// Model used in Delivery API when creating a new Repository.
+    /// </summary>
     public class CreateRepositoryModel
     {
+        /// <summary>
+        /// The name of the repository.
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// The Id of the repository plan
+        /// </summary>
         public long PlanId { get; set; }
     }
 }

--- a/Library/Models/Delivery/CreateRepositorySubscriptionModel.cs
+++ b/Library/Models/Delivery/CreateRepositorySubscriptionModel.cs
@@ -1,0 +1,28 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.SDK.Models.Delivery
+{
+    /// <summary>
+    /// Describes the properties of a new repository subscription. 
+    /// </summary>
+    public class CreateRepositorySubscriptionModel
+    {
+        /// <summary>
+        /// The plan Id that should be used for the new subscription.
+        /// </summary>
+        public long PlanId { get; set; }
+    }
+}

--- a/Library/Models/Delivery/DomainSurveyModel.cs
+++ b/Library/Models/Delivery/DomainSurveyModel.cs
@@ -15,12 +15,24 @@
 
 namespace Nfield.SDK.Models.Delivery
 {
+    /// <summary>
+    /// Describes the main properties of a domain survey. 
+    /// </summary>
     public class DomainSurveyModel
     {
+        /// <summary>
+        /// The Id of the survey
+        /// </summary>
         public long Id { get; set; }
 
+        /// <summary>
+        /// The Name of the survey
+        /// </summary>
         public string Name { get; set; }
 
+        /// <summary>
+        /// The Id of the survey on the nfield system
+        /// </summary>
         public string NfieldSurveyId { get; set; }
     }
 }

--- a/Library/Models/Delivery/DomainSurveyModel.cs
+++ b/Library/Models/Delivery/DomainSurveyModel.cs
@@ -1,0 +1,26 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.SDK.Models.Delivery
+{
+    public class DomainSurveyModel
+    {
+        public long Id { get; set; }
+
+        public string Name { get; set; }
+
+        public string NfieldSurveyId { get; set; }
+    }
+}

--- a/Library/Models/Delivery/DomainSurveyPropertyModel.cs
+++ b/Library/Models/Delivery/DomainSurveyPropertyModel.cs
@@ -20,10 +20,19 @@ namespace Nfield.SDK.Models.Delivery
     /// </summary>
     public class DomainSurveyPropertyModel
     {
+        /// <summary>
+        /// The id of the survey
+        /// </summary>
         public long Id { get; set; }
 
+        /// <summary>
+        /// The key of the survey property
+        /// </summary>
         public string Key { get; set; }
 
+        /// <summary>
+        /// The value of the the survey property's key
+        /// </summary>
         public string Value { get; set; }
     }
 }

--- a/Library/Models/Delivery/DomainSurveyPropertyModel.cs
+++ b/Library/Models/Delivery/DomainSurveyPropertyModel.cs
@@ -1,0 +1,29 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.SDK.Models.Delivery
+{
+    /// <summary>
+    /// Model used in Delivery API operations to describe Domain Survey Property.
+    /// </summary>
+    public class DomainSurveyPropertyModel
+    {
+        public long Id { get; set; }
+
+        public string Key { get; set; }
+
+        public string Value { get; set; }
+    }
+}

--- a/Library/Models/Delivery/FirewallRuleModel.cs
+++ b/Library/Models/Delivery/FirewallRuleModel.cs
@@ -1,0 +1,43 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.SDK.Models.Delivery
+{
+    /// <summary>
+    /// Describes the firewall rule for an Azure Sql Database.
+    /// </summary>
+    public class FirewallRuleModel
+    {
+        /// <summary>
+        /// The identifier for the rule
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// The name of the rule. Unique per database.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The starting IP Address of the allowed range.
+        /// </summary>
+        public string StartIpAddress { get; set; }
+
+        /// <summary>
+        /// The last IP address that will be allowed (in the specified range).
+        /// </summary>
+        public string EndIpAddress { get; set; }
+    }
+}

--- a/Library/Models/Delivery/RepositoryActivityLogModel.cs
+++ b/Library/Models/Delivery/RepositoryActivityLogModel.cs
@@ -1,0 +1,35 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+namespace Nfield.SDK.Models.Delivery
+{
+    /// <summary>
+    /// The repository activity log model.
+    /// </summary>
+    public class RepositoryActivityLogModel
+    {
+        public string NfieldSurveyId { get; set; }
+
+        public string SurveyName { get; set; }
+
+        public string Activity { get; set; }
+
+        public DateTime Timestamp { get; set; }
+
+        public string Username { get; set; }
+    }
+}

--- a/Library/Models/Delivery/RepositoryActivityLogModel.cs
+++ b/Library/Models/Delivery/RepositoryActivityLogModel.cs
@@ -22,14 +22,29 @@ namespace Nfield.SDK.Models.Delivery
     /// </summary>
     public class RepositoryActivityLogModel
     {
+        /// <summary>
+        /// The Id of the survey on the nfield system
+        /// </summary>
         public string NfieldSurveyId { get; set; }
 
+        /// <summary>
+        /// The survey name
+        /// </summary>
         public string SurveyName { get; set; }
 
+        /// <summary>
+        /// The activity being logged
+        /// </summary>
         public string Activity { get; set; }
 
+        /// <summary>
+        /// The timestamp of the activity
+        /// </summary>
         public DateTime Timestamp { get; set; }
 
+        /// <summary>
+        /// The name of the user triggering the activity
+        /// </summary>
         public string Username { get; set; }
     }
 }

--- a/Library/Models/Delivery/RepositoryConnectionInfo.cs
+++ b/Library/Models/Delivery/RepositoryConnectionInfo.cs
@@ -20,12 +20,24 @@ namespace Nfield.SDK.Models.Delivery
     /// </summary>
     public class RepositoryConnectionInfo
     {
+        /// <summary>
+        /// The user Id
+        /// </summary>
         public string UserId { get; set; }
 
+        /// <summary>
+        /// The user password
+        /// </summary>
         public string Password { get; set; }
 
+        /// <summary>
+        /// The database server of the database name of the user
+        /// </summary>
         public string DatabaseServer { get; set; }
 
+        /// <summary>
+        /// The database name of the user
+        /// </summary>
         public string DatabaseName { get; set; }
 
     }

--- a/Library/Models/Delivery/RepositoryConnectionInfo.cs
+++ b/Library/Models/Delivery/RepositoryConnectionInfo.cs
@@ -1,0 +1,32 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.SDK.Models.Delivery
+{
+    /// <summary>
+    /// Class that holds all the required data to connect to a repository database
+    /// </summary>
+    public class RepositoryConnectionInfo
+    {
+        public string UserId { get; set; }
+
+        public string Password { get; set; }
+
+        public string DatabaseServer { get; set; }
+
+        public string DatabaseName { get; set; }
+
+    }
+}

--- a/Library/Models/Delivery/RepositoryMetricsModel.cs
+++ b/Library/Models/Delivery/RepositoryMetricsModel.cs
@@ -1,0 +1,24 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.SDK.Models.Delivery
+{
+    public class RepositoryMetricsModel
+    {
+        public ResourceMetricModel DTU { get; set; }
+
+        public ResourceMetricModel Storage { get; set; }
+    }
+}

--- a/Library/Models/Delivery/RepositoryMetricsModel.cs
+++ b/Library/Models/Delivery/RepositoryMetricsModel.cs
@@ -15,10 +15,19 @@
 
 namespace Nfield.SDK.Models.Delivery
 {
+    /// <summary>
+    /// Model used in Delivery API operations to describe the Repository Metrics
+    /// </summary>
     public class RepositoryMetricsModel
     {
+        /// <summary>
+        /// The DTU values of the respository
+        /// </summary>
         public ResourceMetricModel DTU { get; set; }
 
+        /// <summary>
+        /// The Storage sizes of the repository
+        /// </summary>
         public ResourceMetricModel Storage { get; set; }
     }
 }

--- a/Library/Models/Delivery/RepositoryModel.cs
+++ b/Library/Models/Delivery/RepositoryModel.cs
@@ -15,6 +15,9 @@
 
 namespace Nfield.SDK.Models.Delivery
 {
+    /// <summary>
+    /// Model used in Delivery API for the Repositories.
+    /// </summary>
     public class RepositoryModel
     {
         /// <summary>

--- a/Library/Models/Delivery/RepositoryModel.cs
+++ b/Library/Models/Delivery/RepositoryModel.cs
@@ -1,0 +1,50 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.SDK.Models.Delivery
+{
+    public class RepositoryModel
+    {
+        /// <summary>
+        /// The id of the repository.
+        /// </summary>
+        public long Id { get; set; }
+
+        /// <summary>
+        /// The repository name.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// The status id of the repository.
+        /// </summary>
+        public int StatusId { get; set; }
+
+        /// <summary>
+        /// The plan id of the repository.
+        /// </summary>
+        public int? PlanId { get; set; }
+
+        /// <summary>
+        /// The name of the database that has been provisioned for this repository. 
+        /// </summary>
+        public string DatabaseName { get; set; }
+
+        /// <summary>
+        /// The user that created the repository.
+        /// </summary>
+        public string CreatedBy { get; set; }
+    }
+}

--- a/Library/Models/Delivery/RepositoryPlan.cs
+++ b/Library/Models/Delivery/RepositoryPlan.cs
@@ -1,0 +1,45 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+
+namespace Nfield.SDK.Models.Delivery
+{
+    /// <summary>
+    /// Represents a subscription plan for Data Repositories.
+    /// </summary>
+    public class RepositoryPlan
+    {
+        /// <summary>
+        /// The Id for the plan.
+        /// </summary>
+        public long Id { get; set; }
+
+        /// <summary>
+        /// The name of the plan.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// A short description explaining what's the plan is about.
+        /// </summary>
+        public string Description { get; set; }
+
+        /// <summary>
+        /// The monthly price of the plan.
+        /// </summary>
+        public Amount Price { get; set; }
+    }
+}

--- a/Library/Models/Delivery/RepositoryStatusListModel.cs
+++ b/Library/Models/Delivery/RepositoryStatusListModel.cs
@@ -15,6 +15,9 @@
 
 namespace Nfield.SDK.Models.Delivery
 {
+    /// <summary>
+    /// Model used in Delivery API for the Repository status.
+    /// </summary>
     public class RepositoryStatusListModel
     {
         /// <summary>

--- a/Library/Models/Delivery/RepositoryStatusListModel.cs
+++ b/Library/Models/Delivery/RepositoryStatusListModel.cs
@@ -1,0 +1,31 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.SDK.Models.Delivery
+{
+    public class RepositoryStatusListModel
+    {
+        /// <summary>
+        /// The Id for the status.
+        /// </summary>
+        public int Id { get; set; }
+
+        /// <summary>
+        /// The name of the status.
+        /// </summary>
+        public string Name { get; set; }
+
+    }
+}

--- a/Library/Models/Delivery/RepositorySubscriptionLogModel.cs
+++ b/Library/Models/Delivery/RepositorySubscriptionLogModel.cs
@@ -1,0 +1,35 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+namespace Nfield.SDK.Models.Delivery
+{
+    /// <summary>
+    /// The repository subscription log model.
+    /// </summary>
+    public class RepositorySubscriptionLogModel
+    {
+        public long PlanId { get; set; }
+
+        public string PlanName { get; set; }
+
+        public DateTime StartedAt { get; set; }
+
+        public DateTime? EndedAt { get; set; }
+
+        public string Username { get; set; }
+    }
+}

--- a/Library/Models/Delivery/RepositorySubscriptionLogModel.cs
+++ b/Library/Models/Delivery/RepositorySubscriptionLogModel.cs
@@ -18,18 +18,33 @@ using System;
 namespace Nfield.SDK.Models.Delivery
 {
     /// <summary>
-    /// The repository subscription log model.
+    /// Model used in Delivery API operations to describe the Repository Subscriptions Logs
     /// </summary>
     public class RepositorySubscriptionLogModel
     {
+        /// <summary>
+        /// The id of the repository subscription plan
+        /// </summary>
         public long PlanId { get; set; }
 
+        /// <summary>
+        /// The name of the repository subscription plan
+        /// </summary>
         public string PlanName { get; set; }
 
+        /// <summary>
+        /// The start datetime on the reposity subscription log
+        /// </summary>
         public DateTime StartedAt { get; set; }
 
+        /// <summary>
+        /// The end datetime on the reposity subscription log
+        /// </summary>
         public DateTime? EndedAt { get; set; }
 
+        /// <summary>
+        /// The username on the reposity subscription log
+        /// </summary>
         public string Username { get; set; }
     }
 }

--- a/Library/Models/Delivery/RepositorySurveyModel.cs
+++ b/Library/Models/Delivery/RepositorySurveyModel.cs
@@ -1,0 +1,32 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+namespace Nfield.SDK.Models.Delivery
+{
+    public class RepositorySurveyModel
+    {
+        public long Id { get; set; }
+
+        public string NfieldSurveyId { get; set; }
+
+        public DateTime AddedOn { get; set; }
+
+        public string Status { get; set; }
+
+        public DateTime? LastSyncedAt { get; set; }
+    }
+}

--- a/Library/Models/Delivery/RepositorySurveyModel.cs
+++ b/Library/Models/Delivery/RepositorySurveyModel.cs
@@ -17,16 +17,34 @@ using System;
 
 namespace Nfield.SDK.Models.Delivery
 {
+    /// <summary>
+    /// Describes the main properties of a repository survey. 
+    /// </summary>
     public class RepositorySurveyModel
     {
+        /// <summary>
+        /// The id of the survey
+        /// </summary>
         public long Id { get; set; }
 
+        /// <summary>
+        /// The Id of the survey on the nfield system
+        /// </summary>
         public string NfieldSurveyId { get; set; }
 
+        /// <summary>
+        /// The date when the survey was added to the repository
+        /// </summary>
         public DateTime AddedOn { get; set; }
 
+        /// <summary>
+        /// The status of the survey
+        /// </summary>
         public string Status { get; set; }
 
+        /// <summary>
+        /// Last time the survey was synced
+        /// </summary>
         public DateTime? LastSyncedAt { get; set; }
     }
 }

--- a/Library/Models/Delivery/RepositoryUserModel.cs
+++ b/Library/Models/Delivery/RepositoryUserModel.cs
@@ -1,0 +1,40 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.SDK.Models.Delivery
+{
+    public class RepositoryUserModel
+    {
+        /// <summary>
+        /// The id of the repository user.
+        /// </summary>
+        public long Id { get; set; }
+
+        /// <summary>
+        /// The id of the repository that the user refers to.
+        /// </summary>
+        public long RepositoryId { get; set; }
+
+        /// <summary>
+        /// The repository user name. This should follow the Azure SQL Database user name rules.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// A description for the user.
+        /// </summary>
+        public string Description { get; set; }
+    }
+}

--- a/Library/Models/Delivery/RepositoryUserModel.cs
+++ b/Library/Models/Delivery/RepositoryUserModel.cs
@@ -15,6 +15,9 @@
 
 namespace Nfield.SDK.Models.Delivery
 {
+    /// <summary>
+    /// Model used in Delivery API operations to describe the Repository Users
+    /// </summary>
     public class RepositoryUserModel
     {
         /// <summary>

--- a/Library/Models/Delivery/ResourceMetricModel.cs
+++ b/Library/Models/Delivery/ResourceMetricModel.cs
@@ -1,0 +1,28 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+
+namespace Nfield.SDK.Models.Delivery
+{
+    public class ResourceMetricModel
+    {
+        public double Value { get; set; }
+
+        public double Limit { get; set; }
+
+        public IEnumerable<TimeMetricElementModel> TimeSeries { get; set; }
+    }
+}

--- a/Library/Models/Delivery/ResourceMetricModel.cs
+++ b/Library/Models/Delivery/ResourceMetricModel.cs
@@ -17,12 +17,24 @@ using System.Collections.Generic;
 
 namespace Nfield.SDK.Models.Delivery
 {
+    /// <summary>
+    /// Model used in Delivery API operations to describe Resource Metrics
+    /// </summary>
     public class ResourceMetricModel
     {
+        /// <summary>
+        /// The value of the metric
+        /// </summary>
         public double Value { get; set; }
 
+        /// <summary>
+        /// The limit of the metric
+        /// </summary>
         public double Limit { get; set; }
 
+        /// <summary>
+        /// The value of the metric as a time serie
+        /// </summary>
         public IEnumerable<TimeMetricElementModel> TimeSeries { get; set; }
     }
 }

--- a/Library/Models/Delivery/TimeMetricElementModel.cs
+++ b/Library/Models/Delivery/TimeMetricElementModel.cs
@@ -17,10 +17,19 @@ using System;
 
 namespace Nfield.SDK.Models.Delivery
 {
+    /// <summary>
+    /// Model used in Delivery API operations to describe Time Metrics of the Resource Metrics
+    /// </summary>
     public class TimeMetricElementModel
     {
+        /// <summary>
+        /// The timestamp of the metric
+        /// </summary>
         public DateTime TimeStamp { get; set; }
 
+        /// <summary>
+        /// The value of the metric
+        /// </summary>
         public double Value { get; set; }
     }
 }

--- a/Library/Models/Delivery/TimeMetricElementModel.cs
+++ b/Library/Models/Delivery/TimeMetricElementModel.cs
@@ -1,0 +1,26 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+namespace Nfield.SDK.Models.Delivery
+{
+    public class TimeMetricElementModel
+    {
+        public DateTime TimeStamp { get; set; }
+
+        public double Value { get; set; }
+    }
+}

--- a/Library/Models/Delivery/UpdateDomainSurveyPropertyModel.cs
+++ b/Library/Models/Delivery/UpdateDomainSurveyPropertyModel.cs
@@ -20,8 +20,14 @@ namespace Nfield.SDK.Models.Delivery
     /// </summary>
     public class UpdateDomainSurveyPropertyModel
     {
+        /// <summary>
+        /// The key of the survey property
+        /// </summary>
         public string Key { get; set; }
 
+        /// <summary>
+        /// The value of the the survey property's key
+        /// </summary>
         public string Value { get; set; }
     }
 }

--- a/Library/Models/Delivery/UpdateDomainSurveyPropertyModel.cs
+++ b/Library/Models/Delivery/UpdateDomainSurveyPropertyModel.cs
@@ -1,0 +1,27 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace Nfield.SDK.Models.Delivery
+{
+    /// <summary>
+    /// Model used in Delivery API when updating a Domain Survey Property.
+    /// </summary>
+    public class UpdateDomainSurveyPropertyModel
+    {
+        public string Key { get; set; }
+
+        public string Value { get; set; }
+    }
+}

--- a/Library/Services/INfieldDeliveryRepositoriesService.cs
+++ b/Library/Services/INfieldDeliveryRepositoriesService.cs
@@ -1,0 +1,91 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Nfield.SDK.Models.Delivery;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Set of methods to manage the respositories
+    /// </summary>
+    public interface INfieldDeliveryRepositoriesService
+    {
+        /// <summary>
+        /// Gets a list of repositories for the domain.
+        /// </summary>
+        /// <returns>A list of repositories or an empty list if none exists.</returns>
+        Task<IQueryable<RepositoryModel>> QueryAsync();
+
+        /// <summary>
+        /// Gets the repository for the provided identifier.
+        /// </summary>
+        /// <param name="id">The repository id.</param>
+        /// <returns>The repository associated to the identifier. If the repository doesn't exist, returns a NotFound response.</returns>
+        Task<RepositoryModel> GetAsync(long repositoryId);
+
+        /// <summary>
+        /// Returns the credentials (including server information) to connect to a repository database.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <returns>The repository database credentials.</returns>
+        Task<RepositoryConnectionInfo> GetCredentialsAsync(long repositoryId);
+
+        /// <summary>
+        /// Gets performance metrics for the repository
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <param name="interval">The time interval type (1: for the last day's metrics, 2: for the last week's metrics).</param>
+        /// <returns>The repository metrics.</returns>
+        Task<RepositoryMetricsModel> GetMetricsAsync(long repositoryId, int interval);
+
+
+        /// <summary>
+        /// Gets repository subscription logs.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <returns>The subscription logs.</returns>
+        Task<IQueryable<RepositorySubscriptionLogModel>> QuerySubscriptionsLogsAsync(long repositoryId);
+
+        /// <summary>
+        /// Gets repository activity logs.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <returns>The activity logs.</returns>
+        Task<IQueryable<RepositoryActivityLogModel>> QueryActivityLogsAsync(long repositoryId);
+
+        /// <summary>
+        /// Provisions a new data repository.
+        /// </summary>
+        /// <returns>The repository id, if succeeded. The appropriate exception in case of failure.</returns>
+        Task<RepositoryModel> PostAsync(CreateRepositoryModel model);
+
+        /// <summary>
+        /// Changes the subscription plan of a repository.
+        /// </summary>
+        /// <param name="repositoryId">The repository Id.</param>
+        /// <returns><c>AcceptedResult</c>, if succeeded. The appropriate exception in case of failure. BadRequest in case of error.</returns>
+        Task PostRepositorySubscriptionAsync(long repositoryId, CreateRepositorySubscriptionModel model);
+
+        /// <summary>
+        /// Deletes an existing data repository.
+        /// </summary>
+        /// <param name="id">The repository id.</param>
+        ///<returns> As this is a long running operation, it returns an <c>Accepted</c> response. The appropriate exception will be thrown in case of failure.</returns>
+        Task DeleteAsync(long repositoryId);
+
+    }
+}

--- a/Library/Services/INfieldDeliveryRepositoryFirewallRulesService.cs
+++ b/Library/Services/INfieldDeliveryRepositoryFirewallRulesService.cs
@@ -1,0 +1,57 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Nfield.SDK.Models.Delivery;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Set of methods to manage the respository fiewall rules
+    /// </summary>
+    public interface INfieldDeliveryRepositoryFirewallRulesService
+    {
+        /// <summary>
+        /// Returns the firewall rules configured for the repository database.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <returns>A list of firewall rules</returns>
+        Task<IQueryable<FirewallRuleModel>> QueryAsync(long repositoryId);
+
+        /// <summary>
+        /// Returns the firewall rule for the requested repository based on the given identifier.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <param name="firewallRuleId">The firewall rule id.</param>
+        /// <returns>The firewall rule associated with the requested id.</returns>
+        Task<FirewallRuleModel> GetAsync(long repositoryId, int firewallRuleId);
+
+        /// <summary>
+        /// Adds a firewall rule to allow access to repository database for specific IP addresses.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <returns>The firewall rule id, if succeeded. The appropriate exception in case of failure.</returns>
+        Task<FirewallRuleModel> PostAsync(long repositoryId, FirewallRuleModel model);
+
+        /// <summary>
+        /// Deletes the specified firewall rule from the Repository database.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <param name="firewallRuleId">The id of the firewall rule to delete.</param>
+        /// <returns><c>NoContentResult</c>, if succeeded. The appropriate exception in case of failure.</returns>
+        Task DeleteAsync(long repositoryId, int firewallRuleId);
+    }
+}

--- a/Library/Services/INfieldDeliveryRepositorySurveysService.cs
+++ b/Library/Services/INfieldDeliveryRepositorySurveysService.cs
@@ -1,0 +1,34 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Nfield.SDK.Models.Delivery;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Set of methods to manage the respository surveys
+    /// </summary>
+    public interface INfieldDeliveryRepositorySurveysService
+    {
+        /// <summary>
+        /// Returns the surveys of the given repository.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <returns>The repository surveys.</returns>         
+        Task<IQueryable<RepositorySurveyModel>> QueryAsync(long repositoryId);
+    }
+}

--- a/Library/Services/INfieldDeliveryRepositoryUsersService.cs
+++ b/Library/Services/INfieldDeliveryRepositoryUsersService.cs
@@ -1,0 +1,62 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Nfield.SDK.Models.Delivery;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Set of methods to manage the respository users
+    /// </summary>
+    public interface INfieldDeliveryRepositoryUsersService
+    {
+        /// <summary>
+        /// Returns the list of repository users.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <returns>A list a repository users.</returns>
+        Task<IQueryable<RepositoryUserModel>> QueryAsync(long repositoryId);
+
+        /// <summary>
+        /// Gets a repository user by specified id.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <param name="userId">The user id.</param>
+        /// <returns>A repository user.</returns>
+        Task<RepositoryUserModel> GetAsync(long repositoryId, long userId);
+
+        /// <summary>
+        /// Creates a new repository user based on the given data.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        Task<string> PostAsync(long repositoryId, string repositoryUserName);
+
+        /// <summary>
+        /// Resets the repository user password.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <param name="userId">The repository user id.</param>
+        Task<string> PostAsync(long repositoryId, long userId);
+
+        /// <summary>
+        /// Deletes the repository user.
+        /// </summary>
+        /// <param name="repositoryId">The repository id.</param>
+        /// <param name="userId">The repository user id.</param>
+        Task DeleteAsync(long repositoryId, long userId);
+    }
+}

--- a/Library/Services/INfieldDeliverySettingsService.cs
+++ b/Library/Services/INfieldDeliverySettingsService.cs
@@ -1,0 +1,39 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Nfield.SDK.Models.Delivery;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Set of methods to manage the respository settings
+    /// </summary>
+    public interface INfieldDeliverySettingsService
+    {
+        /// <summary>
+        /// Gets a list of repository statuses.
+        /// </summary>
+        /// <returns>A list of repository statuses.</returns>
+        Task<IQueryable<RepositoryStatusListModel>> QueryRepositoryStatusesAsync();
+
+        /// <summary>
+        /// Gets a list of repository plans.
+        /// </summary>
+        /// <returns>A list of repository plans.</returns>
+        Task<IQueryable<RepositoryPlan>> QueryPlansAsync();
+    }
+}

--- a/Library/Services/INfieldDeliverySurveyPropertiesService.cs
+++ b/Library/Services/INfieldDeliverySurveyPropertiesService.cs
@@ -1,0 +1,65 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Nfield.SDK.Models.Delivery;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Set of methods to manage the respository survey properties
+    /// </summary>
+    public interface INfieldDeliverySurveyPropertiesService
+    {
+        /// <summary>
+        /// Returns the properties for the selected survey.
+        /// </summary>
+        /// <param name="surveyId">The Nfield Survey id.</param>
+        /// <returns>The properties for the selected survey.</returns>         
+        Task<IQueryable<DomainSurveyPropertyModel>> QueryAsync(string surveyId);
+
+        /// <summary>
+        /// Returns the property for the selected survey based on the given identifier.
+        /// </summary>
+        /// <param name="surveyId">The Nfield Survey id.</param>
+        /// <param name="propertyId">The property id.</param>
+        /// <returns>The property of the survey for the given identifier.</returns>         
+        Task<DomainSurveyPropertyModel> GetByIdAsync(string surveyId, long propertyId);
+
+        /// <summary>
+        /// Adds the selected properties to the survey.
+        /// </summary>
+        /// <param name="surveyId">The Nfield Survey id.</param>
+        /// <returns><c>NoContentResult</c>, if succeeded. The appropriate exception in case of failure.</returns>
+        Task PostAsync(string surveyId, CreateDomainSurveyPropertyModel model);
+
+        /// <summary>
+        /// Updates the selected survey property's values.
+        /// </summary>
+        /// <param name="surveyId">The Nfield Survey Id.</param>
+        /// <param name="propertyId">The property id.</param>
+        /// <returns><c>NoContentResult</c>, if succeeded. The appropriate exception in case of failure.</returns>
+        Task PutSurveyPropertyAsync(string surveyId, long propertyId, UpdateDomainSurveyPropertyModel model);
+
+        /// <summary>
+        /// Deletes the selected property from the survey.
+        /// </summary>
+        /// <param name="surveyId">The Nfield Survey Id.</param>
+        /// <param name="propertyId">The property id.</param>
+        /// <returns><c>NoContentResult</c>, if succeeded. The appropriate exception in case of failure.</returns>
+        Task DeleteAsync(string surveyId, long propertyId);
+    }
+}

--- a/Library/Services/INfieldDeliverySurveysService.cs
+++ b/Library/Services/INfieldDeliverySurveysService.cs
@@ -1,0 +1,33 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Nfield.SDK.Models.Delivery;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Set of methods to manage the repository surveys at domain level
+    /// </summary>
+    public interface INfieldDeliverySurveysService
+    {
+        /// <summary>
+        /// Gets a list of surveys that can be added to a repository.
+        /// </summary>
+        /// <returns>A list of surveys.</returns>     
+        Task<IQueryable<DomainSurveyModel>> QueryAsync();
+    }
+}

--- a/Library/Services/Implementation/NfieldDeliveryRepositoriesService.cs
+++ b/Library/Services/Implementation/NfieldDeliveryRepositoriesService.cs
@@ -1,0 +1,151 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Nfield.Extensions;
+using Nfield.Infrastructure;
+using Nfield.SDK.Models.Delivery;
+using Nfield.Services;
+
+namespace Nfield.SDK.Services.Implementation
+{
+    /// <summary>
+    /// Implementation of <see cref="INfieldDeliveryRepositoriesService"/>
+    /// </summary>
+    internal class NfieldDeliveryRepositoriesService : INfieldDeliveryRepositoriesService, INfieldConnectionClientObject
+    {
+        #region Implementation of INfieldDeliveryRepositoriesService
+
+        public Task<IQueryable<RepositoryModel>> QueryAsync()
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, "Delivery/Repositories");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<List<RepositoryModel>>(stringTask.Result).AsQueryable())
+                         .FlattenExceptions();
+        }
+
+        public Task<RepositoryModel> GetAsync(long repositoryId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<RepositoryModel>(stringTask.Result))
+                         .FlattenExceptions();
+        }
+
+        public Task<RepositoryConnectionInfo> GetCredentialsAsync(long repositoryId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Credentials");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<RepositoryConnectionInfo>(stringTask.Result))
+                         .FlattenExceptions();
+        }
+
+        public Task<RepositoryMetricsModel> GetMetricsAsync(long repositoryId, int interval)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Metrics/{interval}");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<RepositoryMetricsModel>(stringTask.Result))
+                         .FlattenExceptions();
+        }
+
+        public Task<IQueryable<RepositorySubscriptionLogModel>> QuerySubscriptionsLogsAsync(long repositoryId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Logs/Subscriptions");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<List<RepositorySubscriptionLogModel>>(stringTask.Result).AsQueryable())
+                         .FlattenExceptions();
+        }
+
+        public Task<IQueryable<RepositoryActivityLogModel>> QueryActivityLogsAsync(long repositoryId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Logs/Activities");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<List<RepositoryActivityLogModel>>(stringTask.Result).AsQueryable())
+                         .FlattenExceptions();
+        }
+
+        public Task<RepositoryModel> PostAsync(CreateRepositoryModel model)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, "Delivery/Repositories");
+
+            return ConnectionClient.Client.PostAsJsonAsync(uri, model)
+                         .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(task => JsonConvert.DeserializeObject<RepositoryModel>(task.Result))
+                         .FlattenExceptions();
+        }
+
+        public Task PostRepositorySubscriptionAsync(long repositoryId, CreateRepositorySubscriptionModel model)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Subscriptions");
+
+            return ConnectionClient.Client.PostAsJsonAsync(uri, model)
+                         .FlattenExceptions();
+        }
+
+        public Task DeleteAsync(long repositoryId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}");
+
+            return ConnectionClient.Client.DeleteAsync(uri).FlattenExceptions();
+        }
+
+        #endregion
+
+        #region Implementation of INfieldConnectionClientObject
+
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        #endregion
+    }
+}

--- a/Library/Services/Implementation/NfieldDeliveryRepositoryFirewallRulesService.cs
+++ b/Library/Services/Implementation/NfieldDeliveryRepositoryFirewallRulesService.cs
@@ -1,0 +1,92 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Nfield.Extensions;
+using Nfield.Infrastructure;
+using Nfield.SDK.Models.Delivery;
+using Nfield.Services;
+
+namespace Nfield.SDK.Services.Implementation
+{
+    /// <summary>
+    /// Implementation of <see cref="INfieldDeliveryRepositoryFirewallRulesService"/>
+    /// </summary>
+    internal class NfieldDeliveryRepositoryFirewallRulesService : INfieldDeliveryRepositoryFirewallRulesService, INfieldConnectionClientObject
+    {
+        #region Implementation of INfieldDeliveryRepositoryFirewallRulesService
+
+        public Task<IQueryable<FirewallRuleModel>> QueryAsync(long repositoryId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/FirewallRules");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<List<FirewallRuleModel>>(stringTask.Result).AsQueryable())
+                         .FlattenExceptions();
+        }
+
+        public Task<FirewallRuleModel> GetAsync(long repositoryId, int firewallRuleId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/FirewallRules/{firewallRuleId}");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<FirewallRuleModel>(stringTask.Result))
+                         .FlattenExceptions();
+        }
+
+        public Task<FirewallRuleModel> PostAsync(long repositoryId, FirewallRuleModel model)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/FirewallRules");
+
+            return ConnectionClient.Client.PostAsJsonAsync(uri, model)
+                        .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
+                        .ContinueWith(task => JsonConvert.DeserializeObject<FirewallRuleModel>(task.Result))
+                        .FlattenExceptions();
+        }
+
+        public Task DeleteAsync(long repositoryId, int firewallRuleId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/FirewallRules/{firewallRuleId}");
+
+            return ConnectionClient.Client.DeleteAsync(uri).FlattenExceptions();
+        }
+
+        #endregion
+
+        #region Implementation of INfieldConnectionClientObject
+
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        #endregion
+
+    }
+}

--- a/Library/Services/Implementation/NfieldDeliveryRepositorySurveysService.cs
+++ b/Library/Services/Implementation/NfieldDeliveryRepositorySurveysService.cs
@@ -1,0 +1,63 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Nfield.Extensions;
+using Nfield.Infrastructure;
+using Nfield.SDK.Models.Delivery;
+using Nfield.Services;
+
+namespace Nfield.SDK.Services.Implementation
+{
+    /// <summary>
+    /// Implementation of <see cref="INfieldDeliveryRepositorySurveysService"/>
+    /// </summary>
+    internal class NfieldDeliveryRepositorySurveysService : INfieldDeliveryRepositorySurveysService, INfieldConnectionClientObject
+    {
+        #region Implementation of INfieldDeliveryRepositorySurveysService
+
+        public Task<IQueryable<RepositorySurveyModel>> QueryAsync(long repositoryId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Surveys");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<List<RepositorySurveyModel>>(stringTask.Result).AsQueryable())
+                         .FlattenExceptions();
+        }
+
+
+        #endregion
+
+        #region Implementation of INfieldConnectionClientObject
+
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        #endregion
+
+    }
+}

--- a/Library/Services/Implementation/NfieldDeliveryRepositoryUsersService.cs
+++ b/Library/Services/Implementation/NfieldDeliveryRepositoryUsersService.cs
@@ -1,0 +1,103 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Nfield.Extensions;
+using Nfield.Infrastructure;
+using Nfield.SDK.Models.Delivery;
+using Nfield.Services;
+
+namespace Nfield.SDK.Services.Implementation
+{
+    /// <summary>
+    /// Implementation of <see cref="INfieldDeliveryRepositoryUsersService"/>
+    /// </summary>
+    internal class NfieldDeliveryRepositoryUsersService : INfieldDeliveryRepositoryUsersService, INfieldConnectionClientObject
+    {
+        #region Implementation of INfieldDeliveryRepositoryUsersService
+
+        public Task<IQueryable<RepositoryUserModel>> QueryAsync(long repositoryId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Users");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<List<RepositoryUserModel>>(stringTask.Result).AsQueryable())
+                         .FlattenExceptions();
+        }
+
+        public Task<RepositoryUserModel> GetAsync(long repositoryId, long userId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Users/{userId}");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<RepositoryUserModel>(stringTask.Result))
+                         .FlattenExceptions();
+        }
+
+        public Task<string> PostAsync(long repositoryId, string repositoryUserName)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Users");
+
+            return ConnectionClient.Client.PostAsync(uri, new StringContent(repositoryUserName))
+                         .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(task => JsonConvert.DeserializeObject<string>(task.Result))
+                         .FlattenExceptions();
+        }
+
+        public Task<string> PostAsync(long repositoryId, long userId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Users/{userId}/Reset");
+
+            return ConnectionClient.Client.PostAsync(uri, null)
+                         .ContinueWith(task => task.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(task => JsonConvert.DeserializeObject<string>(task.Result))
+                         .FlattenExceptions();
+        }
+
+        public Task DeleteAsync(long repositoryId, long userId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Repositories/{repositoryId}/Users/{userId}");
+
+            return ConnectionClient.Client.DeleteAsync(uri).FlattenExceptions();
+        }
+
+        #endregion
+
+        #region Implementation of INfieldConnectionClientObject
+
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        #endregion
+
+    }
+}

--- a/Library/Services/Implementation/NfieldDeliverySettingsService.cs
+++ b/Library/Services/Implementation/NfieldDeliverySettingsService.cs
@@ -1,0 +1,75 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Nfield.Extensions;
+using Nfield.Infrastructure;
+using Nfield.SDK.Models.Delivery;
+using Nfield.Services;
+
+namespace Nfield.SDK.Services.Implementation
+{
+    /// <summary>
+    /// Implementation of <see cref="INfieldDeliverySettingsService"/>
+    /// </summary>
+    internal class NfieldDeliverySettingsService : INfieldDeliverySettingsService, INfieldConnectionClientObject
+    {
+        #region Implementation of INfieldDeliverySettingsService
+
+        public Task<IQueryable<RepositoryStatusListModel>> QueryRepositoryStatusesAsync()
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Settings/RepositoryStatuses");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<List<RepositoryStatusListModel>>(stringTask.Result).AsQueryable())
+                         .FlattenExceptions();
+        }
+
+        public Task<IQueryable<RepositoryPlan>> QueryPlansAsync()
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Settings/Plans");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<List<RepositoryPlan>>(stringTask.Result).AsQueryable())
+                         .FlattenExceptions();
+        }
+
+        #endregion
+
+        #region Implementation of INfieldConnectionClientObject
+
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        #endregion
+
+    }
+}

--- a/Library/Services/Implementation/NfieldDeliverySurveyPropertiesService.cs
+++ b/Library/Services/Implementation/NfieldDeliverySurveyPropertiesService.cs
@@ -1,0 +1,100 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Nfield.Extensions;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using Nfield.SDK.Models.Delivery;
+using Nfield.Services;
+
+namespace Nfield.SDK.Services.Implementation
+{
+    /// <summary>
+    /// Implementation of <see cref="INfieldDeliverySurveyPropertiesService"/>
+    /// </summary>
+    internal class NfieldDeliverySurveyPropertiesService : INfieldDeliverySurveyPropertiesService, INfieldConnectionClientObject
+    {
+        #region Implementation of INfieldDeliverySurveyPropertiesService
+
+        public Task<IQueryable<DomainSurveyPropertyModel>> QueryAsync(string surveyId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Surveys/{surveyId}/Properties");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<List<DomainSurveyPropertyModel>>(stringTask.Result).AsQueryable())
+                         .FlattenExceptions();
+        }
+
+        public Task<DomainSurveyPropertyModel> GetByIdAsync(string surveyId, long propertyId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Surveys/{surveyId}/Properties/{propertyId}");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<DomainSurveyPropertyModel>(stringTask.Result))
+                         .FlattenExceptions();
+        }
+
+        public Task PostAsync(string surveyId, CreateDomainSurveyPropertyModel model)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Surveys/{surveyId}/Properties");
+
+            return ConnectionClient.Client.PostAsJsonAsync(uri, model)
+                         .FlattenExceptions();
+        }
+
+        public Task PutSurveyPropertyAsync(string surveyId, long propertyId, UpdateDomainSurveyPropertyModel model)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Surveys/{surveyId}/Properties/{propertyId}");
+
+            return ConnectionClient.Client.PutAsJsonAsync(uri, model)
+                         .FlattenExceptions();
+        }
+
+        public Task DeleteAsync(string surveyId, long propertyId)
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Surveys/{surveyId}/Properties/{propertyId}");
+
+            return ConnectionClient.Client.DeleteAsync(uri).FlattenExceptions();
+        }
+
+        #endregion
+
+        #region Implementation of INfieldConnectionClientObject
+
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+
+        #endregion
+
+    }
+}

--- a/Library/Services/Implementation/NfieldDeliverySurveysService.cs
+++ b/Library/Services/Implementation/NfieldDeliverySurveysService.cs
@@ -1,0 +1,62 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Nfield.Extensions;
+using Nfield.Infrastructure;
+using Nfield.SDK.Models.Delivery;
+using Nfield.Services;
+
+namespace Nfield.SDK.Services.Implementation
+{
+    /// <summary>
+    /// Implementation of <see cref="INfieldDeliverySurveysService"/>
+    /// </summary>
+    internal class NfieldDeliverySurveysService : INfieldDeliverySurveysService, INfieldConnectionClientObject
+    {
+        #region Implementation of INfieldDeliverySurveysService
+
+        public Task<IQueryable<DomainSurveyModel>> QueryAsync()
+        {
+            var uri = new Uri(ConnectionClient.NfieldServerUri, $"Delivery/Surveys");
+
+            return ConnectionClient.Client.GetAsync(uri)
+                         .ContinueWith(
+                             responseMessageTask => responseMessageTask.Result.Content.ReadAsStringAsync().Result)
+                         .ContinueWith(
+                             stringTask =>
+                             JsonConvert.DeserializeObject<List<DomainSurveyModel>>(stringTask.Result).AsQueryable())
+                         .FlattenExceptions();
+        }
+
+        #endregion
+
+        #region Implementation of INfieldConnectionClientObject
+
+        public INfieldConnectionClient ConnectionClient { get; internal set; }
+
+        public void InitializeNfieldConnection(INfieldConnectionClient connection)
+        {
+            ConnectionClient = connection;
+        }
+
+        #endregion
+
+    }
+}

--- a/Tests/Services/NfieldDeliveryRepositoriesServiceTests.cs
+++ b/Tests/Services/NfieldDeliveryRepositoriesServiceTests.cs
@@ -1,0 +1,252 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.Models;
+using Nfield.SDK.Models.Delivery;
+using Nfield.SDK.Services.Implementation;
+using Nfield.Services.Implementation;
+using Xunit;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Tests for <see cref="NfieldDeliveryRepositoriesService"/>
+    /// </summary>
+    public class NfieldDeliveryRepositoriesServiceTests : NfieldServiceTestsBase
+    {
+        [Fact]
+        public async Task Test_QueryAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryModels = new List<RepositoryModel> { new RepositoryModel { Id = 2, Name = "repositoryName" } };
+            var content = new StringContent(JsonConvert.SerializeObject(repositoryModels));
+
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoriesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.QueryAsync();
+            mockedHttpClient.Verify();
+            Assert.Equal(repositoryModels.First().Name, actual.First().Name);
+        }
+
+        [Fact]
+        public async Task Test_GetAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryModel = new RepositoryModel { Id = 2, Name = "repositoryName" };
+            var content = new StringContent(JsonConvert.SerializeObject(repositoryModel));
+
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryModel.Id}");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoriesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.GetAsync(repositoryModel.Id);
+            mockedHttpClient.Verify();
+            Assert.Equal(repositoryModel.Name, actual.Name);
+        }
+
+        [Fact]
+        public async Task Test_GetCredentialsAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryConnectionInfo = new RepositoryConnectionInfo { UserId = "userId" };
+            var content = new StringContent(JsonConvert.SerializeObject(repositoryConnectionInfo));
+
+            var repositoryId = 1;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Credentials");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoriesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.GetCredentialsAsync(repositoryId);
+            mockedHttpClient.Verify();
+            Assert.Equal(repositoryConnectionInfo.UserId, repositoryConnectionInfo.UserId);
+        }
+
+        [Fact]
+        public async Task Test_GetMetricsAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryMetricsModel = new RepositoryMetricsModel { DTU = new ResourceMetricModel { Value = 3 } };
+            var content = new StringContent(JsonConvert.SerializeObject(repositoryMetricsModel));
+
+            var repositoryId = 1;
+            var interval = 2;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Metrics/{interval}");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoriesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.GetMetricsAsync(repositoryId, interval);
+            mockedHttpClient.Verify();
+            Assert.Equal(repositoryMetricsModel.DTU.Value, actual.DTU.Value);
+        }
+
+        [Fact]
+        public async Task Test_QuerySubscriptionsLogsAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositorySubscriptionLogModels = new List<RepositorySubscriptionLogModel> { new RepositorySubscriptionLogModel { PlanName = "planName" } };
+            var content = new StringContent(JsonConvert.SerializeObject(repositorySubscriptionLogModels));
+
+            var repositoryId = 1;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Logs/Subscriptions");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoriesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.QuerySubscriptionsLogsAsync(repositoryId);
+            mockedHttpClient.Verify();
+            Assert.Equal(repositorySubscriptionLogModels.First().PlanName, actual.First().PlanName);
+        }
+
+        [Fact]
+        public async Task Test_QueryActivityLogsAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryActivityLogModels = new List<RepositoryActivityLogModel> { new RepositoryActivityLogModel { SurveyName = "surveyName" } };
+            var content = new StringContent(JsonConvert.SerializeObject(repositoryActivityLogModels));
+
+            var repositoryId = 1;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Logs/Activities");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoriesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.QueryActivityLogsAsync(repositoryId);
+            mockedHttpClient.Verify();
+            Assert.Equal(repositoryActivityLogModels.First().SurveyName, actual.First().SurveyName);
+        }
+
+        [Fact]
+        public async Task Test_PostAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var createRepositoryModel = new CreateRepositoryModel { Name = "respositoryName" };
+            var content = new StringContent(JsonConvert.SerializeObject(new { Id = 2 }));
+
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories");
+
+            mockedHttpClient
+                .Setup(client => client.PostAsJsonAsync(endpointUri, createRepositoryModel))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoriesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var newRepository = await target.PostAsync(createRepositoryModel);
+
+            mockedHttpClient.Verify();
+            Assert.Equal(2, newRepository.Id);
+        }
+
+        [Fact]
+        public async Task Test_PostRepositorySubscriptionAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var createRepositorySubscriptionModel = new CreateRepositorySubscriptionModel { PlanId = 2 };
+            var content = new StringContent(JsonConvert.SerializeObject(createRepositorySubscriptionModel));
+
+            var repositoryId = 1;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Subscriptions");
+
+            mockedHttpClient
+                .Setup(client => client.PostAsJsonAsync(endpointUri, createRepositorySubscriptionModel))
+                .Returns(CreateTask(HttpStatusCode.OK)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoriesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            await target.PostRepositorySubscriptionAsync(repositoryId, createRepositorySubscriptionModel);
+
+            mockedHttpClient.Verify();
+        }
+
+        [Fact]
+        public async Task Test_DeleteAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryId = 1;
+
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}");
+
+            mockedHttpClient
+                .Setup(client => client.DeleteAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoriesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            await target.DeleteAsync(repositoryId);
+
+            mockedHttpClient.Verify();
+        }
+    }
+}

--- a/Tests/Services/NfieldDeliveryRepositoriesServiceTests.cs
+++ b/Tests/Services/NfieldDeliveryRepositoriesServiceTests.cs
@@ -18,15 +18,12 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using Moq;
 using Newtonsoft.Json;
 using Nfield.Infrastructure;
-using Nfield.Models;
 using Nfield.SDK.Models.Delivery;
 using Nfield.SDK.Services.Implementation;
-using Nfield.Services.Implementation;
 using Xunit;
 
 namespace Nfield.Services

--- a/Tests/Services/NfieldDeliveryRepositoryFirewallRulesServiceTests.cs
+++ b/Tests/Services/NfieldDeliveryRepositoryFirewallRulesServiceTests.cs
@@ -1,0 +1,132 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.SDK.Models.Delivery;
+using Nfield.SDK.Services.Implementation;
+using Xunit;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Tests for <see cref="NfieldDeliveryRepositoryFirewallRulesService"/>
+    /// </summary>
+    public class NfieldDeliveryRepositoryFirewallRulesServiceTests : NfieldServiceTestsBase
+    {
+        [Fact]
+        public async Task Test_QueryAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var firewallRuleModels = new List<FirewallRuleModel> { new FirewallRuleModel { Id = 2, Name = "firewallRule" } };
+            var content = new StringContent(JsonConvert.SerializeObject(firewallRuleModels));
+
+            var repositoryId = 1;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/FirewallRules");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoryFirewallRulesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.QueryAsync(repositoryId);
+            mockedHttpClient.Verify();
+            Assert.Equal(firewallRuleModels.First().Name, actual.First().Name);
+        }
+
+        [Fact]
+        public async Task  Test_GetAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var firewallRuleModel = new FirewallRuleModel { Id = 2, Name = "firewallRule" };
+            var content = new StringContent(JsonConvert.SerializeObject(firewallRuleModel));
+
+            var repositoryId = 1;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/FirewallRules/{firewallRuleModel.Id}");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoryFirewallRulesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.GetAsync(repositoryId, firewallRuleModel.Id);
+            mockedHttpClient.Verify();
+            Assert.Equal(firewallRuleModel.Name, actual.Name);
+        }
+
+        [Fact]
+        public async Task Test_PostAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var firewallRuleModel = new FirewallRuleModel { Name = "firewallRule" };
+            var content = new StringContent(JsonConvert.SerializeObject(new { Id = 2 }));
+
+            var repositoryId = 1;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/FirewallRules");
+
+            mockedHttpClient
+                .Setup(client => client.PostAsJsonAsync(endpointUri, firewallRuleModel))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoryFirewallRulesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var newFirewalRule = await target.PostAsync(repositoryId, firewallRuleModel);
+
+            mockedHttpClient.Verify();
+            Assert.Equal(2, newFirewalRule.Id);
+        }
+
+        [Fact]
+        public async Task Test_DeleteAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryId = 1;
+            var firewallRuleId = 2;
+
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/FirewallRules/{firewallRuleId}");
+
+            mockedHttpClient
+                .Setup(client => client.DeleteAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoryFirewallRulesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            await target.DeleteAsync(repositoryId, firewallRuleId);
+
+            mockedHttpClient.Verify();
+        }
+    }
+}

--- a/Tests/Services/NfieldDeliveryRepositorySurveysServiceTests.cs
+++ b/Tests/Services/NfieldDeliveryRepositorySurveysServiceTests.cs
@@ -1,0 +1,60 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.SDK.Models.Delivery;
+using Nfield.SDK.Services.Implementation;
+using Xunit;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Tests for <see cref="NfieldDeliveryRepositorySurveysService"/>
+    /// </summary>
+    public class NfieldDeliveryRepositorySurveysServiceTests : NfieldServiceTestsBase
+    {
+        [Fact]
+        public async Task Test_QueryAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositorySurveyModels = new List<RepositorySurveyModel> { new RepositorySurveyModel { Id = 1 } };
+            var content = new StringContent(JsonConvert.SerializeObject(repositorySurveyModels));
+
+            var repositoryId = 1;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Surveys");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositorySurveysService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.QueryAsync(repositoryId);
+            mockedHttpClient.Verify();
+            Assert.Equal(repositorySurveyModels.First().Id, actual.First().Id);
+        }
+    }
+}

--- a/Tests/Services/NfieldDeliveryRepositoryUsersServiceTests.cs
+++ b/Tests/Services/NfieldDeliveryRepositoryUsersServiceTests.cs
@@ -1,0 +1,157 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.SDK.Models.Delivery;
+using Nfield.SDK.Services.Implementation;
+using Xunit;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Tests for <see cref="NfieldDeliveryRepositoryUsersService"/>
+    /// </summary>
+    public class NfieldDeliveryRepositoryUsersServiceTests : NfieldServiceTestsBase
+    {
+        [Fact]
+        public async Task Test_QueryAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryUserModels = new List<RepositoryUserModel> { new RepositoryUserModel { Id = 2, Name = "repositoryUser" } };
+            var content = new StringContent(JsonConvert.SerializeObject(repositoryUserModels));
+
+            var repositoryId = 1;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Users");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoryUsersService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.QueryAsync(repositoryId);
+            mockedHttpClient.Verify();
+            Assert.Equal(repositoryUserModels.First().Name, actual.First().Name);
+        }
+
+        [Fact]
+        public async Task Test_GetAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryUserModel = new RepositoryUserModel { Id = 2, Name = "repositoryUser" };
+            var content = new StringContent(JsonConvert.SerializeObject(repositoryUserModel));
+
+            var repositoryId = 1;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Users/{repositoryUserModel.Id}");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoryUsersService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.GetAsync(repositoryId, repositoryUserModel.Id);
+            mockedHttpClient.Verify();
+            Assert.Equal(repositoryUserModel.Name, actual.Name);
+        }
+
+        [Fact]
+        public async Task Test_PostAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryUserName = "repositoryUserName";
+            var content = new StringContent(JsonConvert.SerializeObject(repositoryUserName));
+
+            var repositoryId = 1;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Users");
+
+            mockedHttpClient
+                .Setup(client => client.PostAsync(endpointUri, It.Is<StringContent>(stringContent => stringContent.ReadAsStringAsync().Result.Equals(repositoryUserName))))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoryUsersService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var repositoryUser = await target.PostAsync(repositoryId, repositoryUserName);
+
+            mockedHttpClient.Verify();
+            Assert.Equal(repositoryUserName, repositoryUser);
+        }
+
+        [Fact]
+        public async Task Test_ResetUsertAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var content = new StringContent(JsonConvert.SerializeObject("newUserPassword"));
+
+            var repositoryId = 1;
+            var userId = 2;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Users/{userId}/Reset");
+
+            mockedHttpClient
+                .Setup(client => client.PostAsync(endpointUri, null))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoryUsersService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var repositoryPassword = await target.PostAsync(repositoryId, userId);
+
+            mockedHttpClient.Verify();
+            Assert.Equal("newUserPassword", repositoryPassword);
+        }
+
+        [Fact]
+        public async Task Test_DeleteAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryId = 1;
+            var userId = 2;
+
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Repositories/{repositoryId}/Users/{userId}");
+
+            mockedHttpClient
+                .Setup(client => client.DeleteAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK)).Verifiable();
+
+            var target = new NfieldDeliveryRepositoryUsersService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            await target.DeleteAsync(repositoryId, userId);
+
+            mockedHttpClient.Verify();
+        }
+    }
+}

--- a/Tests/Services/NfieldDeliverySettingsServiceTests.cs
+++ b/Tests/Services/NfieldDeliverySettingsServiceTests.cs
@@ -1,0 +1,82 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Net;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.SDK.Models.Delivery;
+using Nfield.SDK.Services.Implementation;
+using Xunit;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Tests for <see cref="NfieldDeliverySettingsService"/>
+    /// </summary>
+    public class NfieldDeliverySettingsServiceTests : NfieldServiceTestsBase
+    {
+        [Fact]
+        public async Task Test_QueryRepositoryStatusesAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryStatusListModels = new List<RepositoryStatusListModel> { new RepositoryStatusListModel { Id = 2, Name = "repositoryStatus" } };
+            var content = new StringContent(JsonConvert.SerializeObject(repositoryStatusListModels));
+
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Settings/RepositoryStatuses");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliverySettingsService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.QueryRepositoryStatusesAsync();
+            mockedHttpClient.Verify();
+            Assert.Equal(repositoryStatusListModels.First().Name, actual.First().Name);
+        }
+
+        [Fact]
+        public async Task Test_QueryPlansAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var repositoryPlans = new List<RepositoryPlan> { new RepositoryPlan { Id = 2, Name = "repositoryPlan" } };
+            var content = new StringContent(JsonConvert.SerializeObject(repositoryPlans));
+
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Settings/Plans");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliverySettingsService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.QueryPlansAsync();
+            mockedHttpClient.Verify();
+            Assert.Equal(repositoryPlans.First().Name, actual.First().Name);
+        }
+    }
+}

--- a/Tests/Services/NfieldDeliverySurveyPropertiesServiceTests.cs
+++ b/Tests/Services/NfieldDeliverySurveyPropertiesServiceTests.cs
@@ -1,0 +1,156 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.SDK.Models.Delivery;
+using Nfield.SDK.Services.Implementation;
+using Xunit;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Tests for <see cref="NfieldDeliverySurveyPropertiesService"/>
+    /// </summary>
+    public class NfieldDeliverySurveyPropertiesServiceTests : NfieldServiceTestsBase
+    {
+        [Fact]
+        public async Task Test_QueryAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var domainSurveyPropertyModels = new List<DomainSurveyPropertyModel> { new DomainSurveyPropertyModel { Id = 2, Key = "surveyProperty" } };
+            var content = new StringContent(JsonConvert.SerializeObject(domainSurveyPropertyModels));
+
+            var surveyId = "surveyId";
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Surveys/{surveyId}/Properties");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliverySurveyPropertiesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.QueryAsync(surveyId);
+            mockedHttpClient.Verify();
+            Assert.Equal(domainSurveyPropertyModels.First().Key, actual.First().Key);
+        }
+
+        [Fact]
+        public async Task Test_GetByIdAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var domainSurveyPropertyModel = new DomainSurveyPropertyModel { Id = 2, Key = "surveyProperty" };
+            var content = new StringContent(JsonConvert.SerializeObject(domainSurveyPropertyModel));
+
+            var surveyId = "surveyId";
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Surveys/{surveyId}/Properties/{domainSurveyPropertyModel.Id}");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliverySurveyPropertiesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.GetByIdAsync(surveyId, domainSurveyPropertyModel.Id);
+            mockedHttpClient.Verify();
+            Assert.Equal(domainSurveyPropertyModel.Key, actual.Key);
+        }
+
+        [Fact]
+        public async Task Test_PostAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var domainSurveyPropertyModel = new CreateDomainSurveyPropertyModel { Key = "surveyProperty" };
+            var content = new StringContent(JsonConvert.SerializeObject(domainSurveyPropertyModel));
+
+            var surveyId = "surveyId";
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Surveys/{surveyId}/Properties");
+
+            mockedHttpClient
+                .Setup(client => client.PostAsJsonAsync(endpointUri, domainSurveyPropertyModel))
+                .Returns(CreateTask(HttpStatusCode.OK)).Verifiable();
+
+            var target = new NfieldDeliverySurveyPropertiesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            await target.PostAsync(surveyId, domainSurveyPropertyModel);
+
+            mockedHttpClient.Verify();
+        }
+
+        [Fact]
+        public async Task Test_PutSurveyPropertyAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var domainSurveyPropertyModel = new UpdateDomainSurveyPropertyModel { Key = "surveyProperty" };
+            var content = new StringContent(JsonConvert.SerializeObject(domainSurveyPropertyModel));
+
+            var surveyId = "surveyId";
+            var propertyId = 2;
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Surveys/{surveyId}/Properties/{propertyId}");
+
+            mockedHttpClient
+                .Setup(client => client.PutAsJsonAsync(endpointUri, domainSurveyPropertyModel))
+                .Returns(CreateTask(HttpStatusCode.OK)).Verifiable();
+
+            var target = new NfieldDeliverySurveyPropertiesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            await target.PutSurveyPropertyAsync(surveyId, propertyId, domainSurveyPropertyModel);
+
+            mockedHttpClient.Verify();
+        }
+
+        [Fact]
+        public async Task Test_DeleteAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var surveyId = "surveyId";
+            var propertyId = 2;
+
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Surveys/{surveyId}/Properties/{propertyId}");
+
+            mockedHttpClient
+                .Setup(client => client.DeleteAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK)).Verifiable();
+
+            var target = new NfieldDeliverySurveyPropertiesService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            await target.DeleteAsync(surveyId, propertyId);
+
+            mockedHttpClient.Verify();
+        }
+    }
+}

--- a/Tests/Services/NfieldDeliverySurveysServiceTests.cs
+++ b/Tests/Services/NfieldDeliverySurveysServiceTests.cs
@@ -1,0 +1,59 @@
+﻿//    This file is part of Nfield.SDK.
+//
+//    Nfield.SDK is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Lesser General Public License as published by
+//    the Free Software Foundation, either version 3 of the License, or
+//    (at your option) any later version.
+//
+//    Nfield.SDK is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Lesser General Public License for more details.
+//
+//    You should have received a copy of the GNU Lesser General Public License
+//    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json;
+using Nfield.Infrastructure;
+using Nfield.SDK.Models.Delivery;
+using Nfield.SDK.Services.Implementation;
+using Xunit;
+
+namespace Nfield.Services
+{
+    /// <summary>
+    /// Tests for <see cref="NfieldDeliverySurveysService"/>
+    /// </summary>
+    public class NfieldDeliverySurveysServiceTests : NfieldServiceTestsBase
+    {
+        [Fact]
+        public async Task Test_QueryAsync()
+        {
+            var mockedNfieldConnection = new Mock<INfieldConnectionClient>();
+            var mockedHttpClient = CreateHttpClientMock(mockedNfieldConnection);
+
+            var domainSurveyModels = new List<DomainSurveyModel> { new DomainSurveyModel { Id = 2, Name = "surveyName" } };
+            var content = new StringContent(JsonConvert.SerializeObject(domainSurveyModels));
+
+            var endpointUri = new Uri(ServiceAddress, $"Delivery/Surveys");
+
+            mockedHttpClient
+                .Setup(client => client.GetAsync(endpointUri))
+                .Returns(CreateTask(HttpStatusCode.OK, content)).Verifiable();
+
+            var target = new NfieldDeliverySurveysService();
+            target.InitializeNfieldConnection(mockedNfieldConnection.Object);
+
+            var actual = await target.QueryAsync();
+            mockedHttpClient.Verify();
+            Assert.Equal(domainSurveyModels.First().Name, actual.First().Name);
+        }
+    }
+}

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-2.54.{buildId}{suffix}
+2.55.{buildId}{suffix}


### PR DESCRIPTION
[AB#124069](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/124069)

The delivery API endpoints were not part of the SDK.
We have added them so they can be used with the public Api integration tests and simplify it's usage from the public Api

PRs:
- https://github.com/NIPOSoftware/Nfield-SDK/pull/411
- https://github.com/NIPOSoftwareBV/nfield-source/pull/8267