### PR TITLE
Remove  "use legacy parser" option

### DIFF
--- a/Library/Models/SurveyScript.cs
+++ b/Library/Models/SurveyScript.cs
@@ -13,6 +13,7 @@
 //    You should have received a copy of the GNU Lesser General Public License
 //    along with Nfield.SDK.  If not, see <http://www.gnu.org/licenses/>.
 
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 
@@ -50,6 +51,8 @@ namespace Nfield.Models
         /// Please note that the legacy parser will be deprecated in the future and it
         /// is prudent to update scripts to support the latest parser.
         /// </summary>
+        [Obsolete("Using the legacy parser as the main parser is no longer possible")]
+        [JsonIgnore]
         public bool UseLegacyParser { get; set; }
     }
 }

--- a/version.txt
+++ b/version.txt
@@ -17,4 +17,4 @@
 # {major}.{minor}.{buildId}{suffix} where suffix should be either
 # "-alpha", "-beta" or "" (empty) for respectively non-master-branches, master-branches
 # and release-versions (which is triggered once a release is published)
-3.92.{buildId}{suffix}
+3.93.{buildId}{suffix}


### PR DESCRIPTION
[AB#166686](https://dev.azure.com/niposoftware/15ce0e91-931d-4fbf-9169-8c3dde412b54/_workitems/edit/166686)

We decided to use ObsoluteAttribute so build won't breaks but will get a warning.